### PR TITLE
Add VIP-presence gating for contest lifecycle notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,14 @@ uv run python db_main.py --sport NBA GOLF --snapshot-out /tmp/live-snapshot.json
   `dfs_common/discord.py:WebhookSender`).
 - `update_contests.py` updates contest status and `positions_paid` for entries already
   in the database and sends Discord bot notifications for warning/live/completed events,
-  with de-duplication tracked in a notifications table
+  with de-duplication tracked in a notifications table. Those lifecycle notifications
+  are VIP-gated using the DraftKings entrants page before-start lookup: presence
+  `present` and `unknown` still send, while `absent` suppresses the warning/live/
+  completed notification for that contest.
   (`update_contests.py:check_contests_for_completion`,
   `update_contests.py:db_update_contest`, `update_contests.py:create_notifications_table`,
+  `update_contests.py:create_vip_presence_table`,
+  `update_contests.py:_resolve_vip_presence`,
   `update_contests.py:_format_contest_announcement`).
 - `bot/discord_bot.py` runs a long-lived Discord bot that exposes contest lookup and
   health commands (see command handlers in `bot/discord_bot.py:contests`,
@@ -170,6 +175,9 @@ so place the credential file at the repo root before running `db_main.py` or the
 - `contest_warning_schedules.yaml` defines per-sport warning schedules; keys are
   normalized to lowercase and fall back to `default` (`update_contests.py:_load_warning_schedule_map`,
   `update_contests.py:_warning_schedule_for`, `contest_warning_schedules.yaml`).
+- `contest_vip_presence` caches VIP presence decisions for contest notification
+  gating. `present` is sticky, `absent` is refreshed every 10 minutes before start,
+  and `absent` becomes sticky after start once the contest is locked in.
 - `sheet_gids.yaml` is a YAML mapping of sheet title to numeric gid; used for building
   sheet links (`update_contests.py:_load_sheet_gid_map`, `bot/discord_bot.py:_load_sheet_gid_map`).
   It can be generated via `generate_sheet_gids.py` (`generate_sheet_gids.py:main`,

--- a/src/dk_results/classes/draftkings.py
+++ b/src/dk_results/classes/draftkings.py
@@ -291,6 +291,23 @@ class Draftkings:
         r.raise_for_status()
         return r.json()
 
+    def get_contest_entrants_page(
+        self,
+        contest_id: int,
+        page_no: int,
+        timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
+    ) -> str:
+        """
+        Fetch a single entrants page HTML fragment for a contest.
+        """
+        to = timeout or self.timeout_sec
+        sess = session or self.session
+        url = f"https://www.draftkings.com/contest/getentrantsmorewithhep?contestId={contest_id}&pageNo={page_no}"
+        r = sess.get(url, timeout=to)
+        r.raise_for_status()
+        return r.text
+
     def download_contest_rows(
         self,
         contest_id: int,

--- a/src/dk_results/cli/update_contests.py
+++ b/src/dk_results/cli/update_contests.py
@@ -626,9 +626,17 @@ def check_contests_for_completion(conn) -> None:
     create_notifications_table(conn)
     create_vip_presence_table(conn)
     sender = _build_discord_sender()
+    dk_client: Draftkings | None = None
+    vip_names: list[str] = []
     if sender:
-        dk_client = Draftkings()
         vip_names = _load_vips()
+        try:
+            dk_client = Draftkings()
+        except Exception:
+            logger.warning(
+                "VIP presence checks disabled; Draftkings client initialization failed",
+                exc_info=True,
+            )
 
     if sender:
         logged_schedules: set[str] = set()
@@ -673,13 +681,15 @@ def check_contests_for_completion(conn) -> None:
                         warning_minutes,
                     )
                     continue
-                vip_presence = _resolve_vip_presence(
-                    conn,
-                    dk=dk_client,
-                    dk_id=dk_id,
-                    start_date=str(start_date),
-                    vip_names=vip_names,
-                )
+                vip_presence = VIP_UNKNOWN
+                if dk_client is not None:
+                    vip_presence = _resolve_vip_presence(
+                        conn,
+                        dk=dk_client,
+                        dk_id=dk_id,
+                        start_date=str(start_date),
+                        vip_names=vip_names,
+                    )
                 if vip_presence == VIP_ABSENT:
                     logger.info(
                         "skipping warning notification for %s dk_id=%s (%sm); vip_presence=absent",
@@ -806,13 +816,15 @@ def check_contests_for_completion(conn) -> None:
                         dk_id,
                     )
                 if is_new_live and is_primary_live and not db_has_notification(conn, dk_id, "live"):
-                    vip_presence = _resolve_vip_presence(
-                        conn,
-                        dk=dk_client,
-                        dk_id=dk_id,
-                        start_date=str(start_date),
-                        vip_names=vip_names,
-                    )
+                    vip_presence = VIP_UNKNOWN
+                    if dk_client is not None:
+                        vip_presence = _resolve_vip_presence(
+                            conn,
+                            dk=dk_client,
+                            dk_id=dk_id,
+                            start_date=str(start_date),
+                            vip_names=vip_names,
+                        )
                     if vip_presence == VIP_ABSENT:
                         logger.info(
                             "skipping live notification for %s dk_id=%s; vip_presence=absent",
@@ -848,13 +860,15 @@ def check_contests_for_completion(conn) -> None:
 
                 if is_new_completed:
                     if db_has_notification(conn, dk_id, "live") and not db_has_notification(conn, dk_id, "completed"):
-                        vip_presence = _resolve_vip_presence(
-                            conn,
-                            dk=dk_client,
-                            dk_id=dk_id,
-                            start_date=str(start_date),
-                            vip_names=vip_names,
-                        )
+                        vip_presence = VIP_UNKNOWN
+                        if dk_client is not None:
+                            vip_presence = _resolve_vip_presence(
+                                conn,
+                                dk=dk_client,
+                                dk_id=dk_id,
+                                start_date=str(start_date),
+                                vip_names=vip_names,
+                            )
                         if vip_presence == VIP_ABSENT:
                             logger.info(
                                 "skipping completed notification for %s dk_id=%s; vip_presence=absent",

--- a/src/dk_results/cli/update_contests.py
+++ b/src/dk_results/cli/update_contests.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sqlite3
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from pathlib import Path
@@ -42,6 +43,11 @@ CONTEST_WARNING_MINUTES = int(os.getenv("CONTEST_WARNING_MINUTES", "25"))
 WARNING_SCHEDULE_FILE_ENV = "CONTEST_WARNING_SCHEDULE_FILE"
 DEFAULT_WARNING_SCHEDULE_FILE = str(repo_file("contest_warning_schedules.yaml"))
 _DEFAULT_WARNING_SCHEDULE = [CONTEST_WARNING_MINUTES]
+VIP_PRESENT = "present"
+VIP_ABSENT = "absent"
+VIP_UNKNOWN = "unknown"
+VIP_ABSENT_REFRESH_MINUTES = 10
+VIP_ENTRANT_PAGE_LIMIT = 50
 
 SPORT_EMOJI = {
     "CFB": "🏈",
@@ -246,6 +252,42 @@ def create_notifications_table(conn) -> None:
     conn.commit()
 
 
+def create_vip_presence_table(conn) -> None:
+    sql = """
+    CREATE TABLE IF NOT EXISTS contest_vip_presence (
+        dk_id INTEGER PRIMARY KEY,
+        status TEXT NOT NULL,
+        checked_at datetime NOT NULL DEFAULT (datetime('now', 'localtime'))
+    );
+    """
+    conn.execute(sql)
+    conn.commit()
+
+
+def db_get_vip_presence(conn, dk_id: int) -> tuple[str, str] | None:
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT status, checked_at FROM contest_vip_presence WHERE dk_id=? LIMIT 1",
+        (dk_id,),
+    )
+    return cur.fetchone()
+
+
+def db_upsert_vip_presence(conn, dk_id: int, status: str) -> None:
+    create_vip_presence_table(conn)
+    conn.execute(
+        """
+        INSERT INTO contest_vip_presence (dk_id, status)
+        VALUES (?, ?)
+        ON CONFLICT(dk_id) DO UPDATE SET
+            status=excluded.status,
+            checked_at=datetime('now', 'localtime')
+        """,
+        (dk_id, status),
+    )
+    conn.commit()
+
+
 def db_has_notification(conn, dk_id: int, event: str) -> bool:
     cur = conn.cursor()
     cur.execute(
@@ -313,6 +355,87 @@ def _vip_key(name: Any) -> str:
     if not isinstance(name, str):
         return ""
     return name.strip().lower()
+
+
+_ENTRANT_USERNAME_RE = re.compile(r"""data-un\s*=\s*['"]([^'"]+)['"]""", re.IGNORECASE)
+
+
+def _parse_entrant_usernames(html: str) -> list[str]:
+    if not html:
+        return []
+    return [match.strip().lower() for match in _ENTRANT_USERNAME_RE.findall(html) if match.strip()]
+
+
+def _entrant_payload_is_ambiguous(html: str, entrants: list[str]) -> bool:
+    if entrants:
+        return False
+    lowered = html.lower()
+    return "data-un" in lowered
+
+
+def _should_refresh_absent(checked_at: str, start_date: str) -> bool:
+    def _normalize_local(dt: datetime.datetime) -> datetime.datetime:
+        local_tz = datetime.datetime.now().astimezone().tzinfo
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=local_tz)
+        return dt.astimezone(local_tz)
+
+    checked_dt = _parse_start_date(checked_at)
+    start_dt = _parse_start_date(start_date)
+    if not checked_dt or not start_dt:
+        return True
+
+    checked_local = _normalize_local(checked_dt)
+    start_local = _normalize_local(start_dt)
+    now_local = datetime.datetime.now(start_local.tzinfo)
+    if now_local < start_local:
+        return (now_local - checked_local) >= datetime.timedelta(minutes=VIP_ABSENT_REFRESH_MINUTES)
+    return False
+
+
+def _resolve_vip_presence(
+    conn,
+    *,
+    dk: Draftkings,
+    dk_id: int,
+    start_date: str,
+    vip_names: list[str],
+) -> str:
+    create_vip_presence_table(conn)
+    if not vip_names:
+        return VIP_UNKNOWN
+
+    vip_keys = {_vip_key(name) for name in vip_names if _vip_key(name)}
+    if not vip_keys:
+        return VIP_UNKNOWN
+
+    cached = db_get_vip_presence(conn, dk_id)
+    if cached:
+        cached_status, checked_at = cached
+        if cached_status == VIP_PRESENT:
+            return VIP_PRESENT
+        if cached_status == VIP_ABSENT and not _should_refresh_absent(checked_at, start_date):
+            return VIP_ABSENT
+
+    try:
+        for page_no in range(1, VIP_ENTRANT_PAGE_LIMIT + 1):
+            html = dk.get_contest_entrants_page(dk_id, page_no)
+            entrants = _parse_entrant_usernames(html)
+            if _entrant_payload_is_ambiguous(html, entrants):
+                logger.warning("entrant payload parse ambiguity for dk_id=%s page=%s", dk_id, page_no)
+                return VIP_UNKNOWN
+            if not entrants:
+                db_upsert_vip_presence(conn, dk_id, VIP_ABSENT)
+                return VIP_ABSENT
+            if any(name in vip_keys for name in entrants):
+                db_upsert_vip_presence(conn, dk_id, VIP_PRESENT)
+                return VIP_PRESENT
+    except Exception:
+        logger.warning("VIP presence check failed for dk_id=%s", dk_id, exc_info=True)
+        return VIP_UNKNOWN
+
+    logger.info("vip presence page cap hit for dk_id=%s; returning unknown", dk_id)
+    return VIP_UNKNOWN
 
 
 def _load_vips() -> list[str]:
@@ -501,7 +624,11 @@ def _maybe_send_soft_finish_announcement(
 def check_contests_for_completion(conn) -> None:
     """Check each contest for completion/positions_paid data."""
     create_notifications_table(conn)
+    create_vip_presence_table(conn)
     sender = _build_discord_sender()
+    if sender:
+        dk_client = Draftkings()
+        vip_names = _load_vips()
 
     if sender:
         logged_schedules: set[str] = set()
@@ -541,6 +668,21 @@ def check_contests_for_completion(conn) -> None:
                 if db_has_notification(conn, dk_id, warning_key):
                     logger.debug(
                         "warning already sent for %s dk_id=%s (%sm)",
+                        sport_cls.name,
+                        dk_id,
+                        warning_minutes,
+                    )
+                    continue
+                vip_presence = _resolve_vip_presence(
+                    conn,
+                    dk=dk_client,
+                    dk_id=dk_id,
+                    start_date=str(start_date),
+                    vip_names=vip_names,
+                )
+                if vip_presence == VIP_ABSENT:
+                    logger.info(
+                        "skipping warning notification for %s dk_id=%s (%sm); vip_presence=absent",
                         sport_cls.name,
                         dk_id,
                         warning_minutes,
@@ -664,6 +806,20 @@ def check_contests_for_completion(conn) -> None:
                         dk_id,
                     )
                 if is_new_live and is_primary_live and not db_has_notification(conn, dk_id, "live"):
+                    vip_presence = _resolve_vip_presence(
+                        conn,
+                        dk=dk_client,
+                        dk_id=dk_id,
+                        start_date=str(start_date),
+                        vip_names=vip_names,
+                    )
+                    if vip_presence == VIP_ABSENT:
+                        logger.info(
+                            "skipping live notification for %s dk_id=%s; vip_presence=absent",
+                            sport_name,
+                            dk_id,
+                        )
+                        continue
                     message = _format_contest_announcement(
                         "Contest started",
                         sport_name,
@@ -692,6 +848,20 @@ def check_contests_for_completion(conn) -> None:
 
                 if is_new_completed:
                     if db_has_notification(conn, dk_id, "live") and not db_has_notification(conn, dk_id, "completed"):
+                        vip_presence = _resolve_vip_presence(
+                            conn,
+                            dk=dk_client,
+                            dk_id=dk_id,
+                            start_date=str(start_date),
+                            vip_names=vip_names,
+                        )
+                        if vip_presence == VIP_ABSENT:
+                            logger.info(
+                                "skipping completed notification for %s dk_id=%s; vip_presence=absent",
+                                sport_name,
+                                dk_id,
+                            )
+                            continue
                         message = _format_contest_announcement(
                             "Contest ended",
                             sport_name,

--- a/tests/test_update_contests.py
+++ b/tests/test_update_contests.py
@@ -7,6 +7,40 @@ import yaml
 
 import dk_results.cli.update_contests as update_contests
 
+CONTESTS_TABLE_SQL = """
+CREATE TABLE contests (
+    dk_id INTEGER PRIMARY KEY,
+    sport varchar(10) NOT NULL,
+    name varchar(50) NOT NULL,
+    start_date datetime NOT NULL,
+    draft_group INTEGER NOT NULL,
+    total_prizes INTEGER NOT NULL,
+    entries INTEGER NOT NULL,
+    positions_paid INTEGER,
+    entry_fee INTEGER NOT NULL,
+    entry_count INTEGER NOT NULL,
+    max_entry_count INTEGER NOT NULL,
+    completed INTEGER NOT NULL DEFAULT 0,
+    status TEXT
+);
+"""
+
+
+def _create_contests_table(conn: sqlite3.Connection) -> None:
+    conn.execute(CONTESTS_TABLE_SQL)
+    conn.commit()
+
+
+def _make_sender():
+    class FakeSender:
+        def __init__(self):
+            self.messages = []
+
+        def send_message(self, message: str) -> None:
+            self.messages.append(message)
+
+    return FakeSender()
+
 
 def test_parse_start_date_handles_str_and_datetime():
     dt = datetime.datetime(2026, 1, 1, 0, 0, 0)
@@ -1446,3 +1480,310 @@ def test_soft_finish_runs_despite_skip_draft_groups_short_circuit(monkeypatch, t
     update_contests.check_contests_for_completion(conn)
 
     assert len(sender.messages) == 1
+
+
+def test_vip_presence_resolver_uses_draftkings_entrant_page_fetch():
+    conn = sqlite3.connect(":memory:")
+    update_contests.create_vip_presence_table(conn)
+    calls: list[tuple[int, int]] = []
+
+    class FakeDK:
+        def get_contest_entrants_page(self, contest_id: int, page_no: int, timeout=None, session=None):
+            calls.append((contest_id, page_no))
+            if page_no == 1:
+                return "<tr><td data-un='vipone'></td></tr>"
+            return ""
+
+    status = update_contests._resolve_vip_presence(
+        conn,
+        dk=FakeDK(),
+        dk_id=123,
+        start_date="2026-03-29 13:35:00",
+        vip_names=["VipOne"],
+    )
+
+    assert status == update_contests.VIP_PRESENT
+    assert calls == [(123, 1)]
+    assert update_contests.db_get_vip_presence(conn, 123)[0] == update_contests.VIP_PRESENT
+
+
+def test_resolve_vip_presence_marks_absent_when_all_pages_scanned():
+    conn = sqlite3.connect(":memory:")
+    update_contests.create_vip_presence_table(conn)
+
+    class FakeDK:
+        def get_contest_entrants_page(self, contest_id: int, page_no: int, timeout=None, session=None):
+            if page_no == 1:
+                return "<tr><td data-un='user1'></td><td data-un='user2'></td></tr>"
+            return ""
+
+    status = update_contests._resolve_vip_presence(
+        conn,
+        dk=FakeDK(),
+        dk_id=202,
+        start_date="2026-03-29 13:35:00",
+        vip_names=["vip_alpha", "vip_beta"],
+    )
+
+    assert status == update_contests.VIP_ABSENT
+    assert update_contests.db_get_vip_presence(conn, 202)[0] == update_contests.VIP_ABSENT
+
+
+def test_resolve_vip_presence_returns_unknown_on_fetch_error():
+    conn = sqlite3.connect(":memory:")
+    update_contests.create_vip_presence_table(conn)
+
+    class FakeDK:
+        def get_contest_entrants_page(self, contest_id: int, page_no: int, timeout=None, session=None):
+            raise RuntimeError("network down")
+
+    status = update_contests._resolve_vip_presence(
+        conn,
+        dk=FakeDK(),
+        dk_id=303,
+        start_date="2026-03-29 13:35:00",
+        vip_names=["vip_alpha"],
+    )
+
+    assert status == update_contests.VIP_UNKNOWN
+    assert update_contests.db_get_vip_presence(conn, 303) is None
+
+
+def test_resolve_vip_presence_returns_unknown_when_page_cap_hit(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    update_contests.create_vip_presence_table(conn)
+    monkeypatch.setattr(update_contests, "VIP_ENTRANT_PAGE_LIMIT", 2)
+    calls: list[int] = []
+
+    class FakeDK:
+        def get_contest_entrants_page(self, contest_id: int, page_no: int, timeout=None, session=None):
+            calls.append(page_no)
+            return "<tr><td data-un='user1'></td></tr>"
+
+    status = update_contests._resolve_vip_presence(
+        conn,
+        dk=FakeDK(),
+        dk_id=404,
+        start_date="2026-03-29 13:35:00",
+        vip_names=["vip_alpha"],
+    )
+
+    assert status == update_contests.VIP_UNKNOWN
+    assert calls == [1, 2]
+    assert update_contests.db_get_vip_presence(conn, 404) is None
+
+
+def test_parse_entrant_usernames_accepts_single_or_double_quotes():
+    html = "<td data-un='vip_alpha'></td><td data-un=\"vip_beta\"></td>"
+    names = update_contests._parse_entrant_usernames(html)
+    assert names == ["vip_alpha", "vip_beta"]
+
+
+def test_should_refresh_absent_normalizes_timezone_before_subtraction():
+    now_local = datetime.datetime.now().astimezone().replace(microsecond=0)
+    checked_at = (now_local - datetime.timedelta(minutes=11)).replace(tzinfo=None).isoformat(sep=" ")
+    start_date = (now_local + datetime.timedelta(minutes=30)).astimezone(datetime.timezone.utc).isoformat()
+
+    assert update_contests._should_refresh_absent(checked_at, start_date) is True
+
+
+def test_should_refresh_absent_is_sticky_after_start():
+    now_local = datetime.datetime.now().replace(microsecond=0)
+    checked_at = (now_local - datetime.timedelta(minutes=30)).isoformat(sep=" ")
+    start_date = (now_local - datetime.timedelta(minutes=1)).isoformat(sep=" ")
+
+    assert update_contests._should_refresh_absent(checked_at, start_date) is False
+
+
+def test_warning_notification_suppressed_when_vip_presence_absent(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    _create_contests_table(conn)
+    update_contests.create_notifications_table(conn)
+    update_contests.create_vip_presence_table(conn)
+    start_date = (datetime.datetime.now() + datetime.timedelta(minutes=10)).strftime("%Y-%m-%d %H:%M:%S")
+    conn.execute(
+        """
+        INSERT INTO contests (
+            dk_id, sport, name, start_date, draft_group, total_prizes, entries,
+            positions_paid, entry_fee, entry_count, max_entry_count, completed, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (123, "NBA", "Test Contest", start_date, 1, 0, 0, None, 25, 0, 0, 0, None),
+    )
+    conn.commit()
+
+    class DummySport:
+        name = "NBA"
+        sheet_min_entry_fee = 25
+        keyword = "%"
+
+    resolver_calls: list[int] = []
+
+    def fake_resolver(conn, *, dk, dk_id, start_date, vip_names):
+        resolver_calls.append(dk_id)
+        return update_contests.VIP_ABSENT
+
+    sender = _make_sender()
+    monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
+    monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
+    monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [25])
+    monkeypatch.setattr(update_contests, "_resolve_vip_presence", fake_resolver)
+    monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
+
+    update_contests.check_contests_for_completion(conn)
+
+    assert resolver_calls == [123]
+    assert sender.messages == []
+    assert update_contests.db_has_notification(conn, 123, "warning:25") is False
+
+
+def test_warning_notification_sent_when_vip_presence_unknown(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    _create_contests_table(conn)
+    update_contests.create_notifications_table(conn)
+    update_contests.create_vip_presence_table(conn)
+    start_date = (datetime.datetime.now() + datetime.timedelta(minutes=10)).strftime("%Y-%m-%d %H:%M:%S")
+    conn.execute(
+        """
+        INSERT INTO contests (
+            dk_id, sport, name, start_date, draft_group, total_prizes, entries,
+            positions_paid, entry_fee, entry_count, max_entry_count, completed, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (124, "NBA", "Test Contest", start_date, 1, 0, 0, None, 25, 0, 0, 0, None),
+    )
+    conn.commit()
+
+    class DummySport:
+        name = "NBA"
+        sheet_min_entry_fee = 25
+        keyword = "%"
+
+    resolver_calls: list[int] = []
+
+    def fake_resolver(conn, *, dk, dk_id, start_date, vip_names):
+        resolver_calls.append(dk_id)
+        return update_contests.VIP_UNKNOWN
+
+    sender = _make_sender()
+    monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
+    monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
+    monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [25])
+    monkeypatch.setattr(update_contests, "_resolve_vip_presence", fake_resolver)
+    monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
+
+    update_contests.check_contests_for_completion(conn)
+
+    assert resolver_calls == [124]
+    assert len(sender.messages) == 1
+    assert "Contest starting soon (25m)" in sender.messages[0]
+    assert update_contests.db_has_notification(conn, 124, "warning:25") is True
+
+
+def test_live_notification_suppressed_when_vip_presence_absent(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    _create_contests_table(conn)
+    update_contests.create_notifications_table(conn)
+    update_contests.create_vip_presence_table(conn)
+    start_date = "2026-03-29 12:00:00"
+    conn.execute(
+        """
+        INSERT INTO contests (
+            dk_id, sport, name, start_date, draft_group, total_prizes, entries,
+            positions_paid, entry_fee, entry_count, max_entry_count, completed, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (222, "NBA", "Live Contest", start_date, 55, 0, 0, None, 25, 0, 0, 0, "SCHEDULED"),
+    )
+    conn.commit()
+
+    class DummySport:
+        name = "NBA"
+        sheet_min_entry_fee = 25
+        keyword = "%"
+
+    sender = _make_sender()
+    monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
+    monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
+    monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [])
+    monkeypatch.setattr(
+        update_contests,
+        "_resolve_vip_presence",
+        lambda *_args, **_kwargs: update_contests.VIP_ABSENT,
+    )
+    monkeypatch.setattr(
+        update_contests,
+        "db_get_incomplete_contests",
+        lambda _c: [(222, 55, 0, None, "SCHEDULED", 0, "Live Contest", start_date, "NBA")],
+    )
+    monkeypatch.setattr(
+        update_contests,
+        "get_contest_data",
+        lambda _id: {"positions_paid": 100, "status": "LIVE", "completed": 0, "entries": 400},
+    )
+    monkeypatch.setattr(
+        update_contests,
+        "db_get_live_contest",
+        lambda *_a, **_k: (222, "Live Contest", 55, 100, start_date),
+    )
+    monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
+
+    update_contests.check_contests_for_completion(conn)
+
+    assert sender.messages == []
+    assert update_contests.db_has_notification(conn, 222, "live") is False
+
+
+def test_completed_notification_suppressed_when_vip_presence_absent(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    _create_contests_table(conn)
+    update_contests.create_notifications_table(conn)
+    update_contests.create_vip_presence_table(conn)
+    start_date = "2026-03-29 12:00:00"
+    conn.execute(
+        """
+        INSERT INTO contests (
+            dk_id, sport, name, start_date, draft_group, total_prizes, entries,
+            positions_paid, entry_fee, entry_count, max_entry_count, completed, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (333, "NBA", "Completed Contest", start_date, 65, 0, 0, None, 25, 0, 0, 0, "SCHEDULED"),
+    )
+    update_contests.db_insert_notification(conn, 333, "live")
+    conn.commit()
+
+    class DummySport:
+        name = "NBA"
+        sheet_min_entry_fee = 25
+        keyword = "%"
+
+    sender = _make_sender()
+    monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
+    monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
+    monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [])
+    monkeypatch.setattr(
+        update_contests,
+        "_resolve_vip_presence",
+        lambda *_args, **_kwargs: update_contests.VIP_ABSENT,
+    )
+    monkeypatch.setattr(
+        update_contests,
+        "db_get_incomplete_contests",
+        lambda _c: [(333, 65, 0, None, "SCHEDULED", 0, "Completed Contest", start_date, "NBA")],
+    )
+    monkeypatch.setattr(
+        update_contests,
+        "get_contest_data",
+        lambda _id: {"positions_paid": 100, "status": "COMPLETED", "completed": 1, "entries": 400},
+    )
+    monkeypatch.setattr(
+        update_contests,
+        "db_get_live_contest",
+        lambda *_a, **_k: (333, "Completed Contest", 65, 100, start_date),
+    )
+    monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
+
+    update_contests.check_contests_for_completion(conn)
+
+    assert sender.messages == []
+    assert update_contests.db_has_notification(conn, 333, "completed") is False

--- a/tests/test_update_contests.py
+++ b/tests/test_update_contests.py
@@ -1,6 +1,7 @@
 import datetime
 import runpy
 import sqlite3
+import sys
 
 import pytest
 import yaml
@@ -852,7 +853,12 @@ def test_module_main_executes(monkeypatch):
         raise sqlite3.Error("boom")
 
     monkeypatch.setattr("sqlite3.connect", boom)
-    runpy.run_module("dk_results.cli.update_contests", run_name="__main__")
+    existing = sys.modules.pop("dk_results.cli.update_contests", None)
+    try:
+        runpy.run_module("dk_results.cli.update_contests", run_name="__main__")
+    finally:
+        if existing is not None:
+            sys.modules["dk_results.cli.update_contests"] = existing
 
 
 def test_build_discord_sender_success_path(monkeypatch):

--- a/tests/test_update_contests.py
+++ b/tests/test_update_contests.py
@@ -1680,6 +1680,46 @@ def test_warning_notification_sent_when_vip_presence_unknown(monkeypatch):
     assert update_contests.db_has_notification(conn, 124, "warning:25") is True
 
 
+def test_warning_notification_sent_when_draftkings_client_init_fails(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    _create_contests_table(conn)
+    update_contests.create_notifications_table(conn)
+    update_contests.create_vip_presence_table(conn)
+    start_date = (datetime.datetime.now() + datetime.timedelta(minutes=10)).strftime("%Y-%m-%d %H:%M:%S")
+    conn.execute(
+        """
+        INSERT INTO contests (
+            dk_id, sport, name, start_date, draft_group, total_prizes, entries,
+            positions_paid, entry_fee, entry_count, max_entry_count, completed, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (125, "NBA", "Init Failure Contest", start_date, 1, 0, 0, None, 25, 0, 0, 0, None),
+    )
+    conn.commit()
+
+    class DummySport:
+        name = "NBA"
+        sheet_min_entry_fee = 25
+        keyword = "%"
+
+    class FailingDraftkings:
+        def __init__(self):
+            raise RuntimeError("can't find cookies file")
+
+    sender = _make_sender()
+    monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
+    monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
+    monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [25])
+    monkeypatch.setattr(update_contests, "Draftkings", FailingDraftkings)
+    monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
+
+    update_contests.check_contests_for_completion(conn)
+
+    assert len(sender.messages) == 1
+    assert "Contest starting soon (25m)" in sender.messages[0]
+    assert update_contests.db_has_notification(conn, 125, "warning:25") is True
+
+
 def test_live_notification_suppressed_when_vip_presence_absent(monkeypatch):
     conn = sqlite3.connect(":memory:")
     _create_contests_table(conn)

--- a/tests/test_update_contests.py
+++ b/tests/test_update_contests.py
@@ -43,6 +43,11 @@ def _make_sender():
     return FakeSender()
 
 
+class _StubDraftkings:
+    def __init__(self):
+        pass
+
+
 def test_parse_start_date_handles_str_and_datetime():
     dt = datetime.datetime(2026, 1, 1, 0, 0, 0)
     assert update_contests._parse_start_date(dt) == dt
@@ -1633,6 +1638,7 @@ def test_warning_notification_suppressed_when_vip_presence_absent(monkeypatch):
     monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
     monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
     monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [25])
+    monkeypatch.setattr(update_contests, "Draftkings", _StubDraftkings)
     monkeypatch.setattr(update_contests, "_resolve_vip_presence", fake_resolver)
     monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
 
@@ -1675,6 +1681,7 @@ def test_warning_notification_sent_when_vip_presence_unknown(monkeypatch):
     monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
     monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
     monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [25])
+    monkeypatch.setattr(update_contests, "Draftkings", _StubDraftkings)
     monkeypatch.setattr(update_contests, "_resolve_vip_presence", fake_resolver)
     monkeypatch.setattr(update_contests, "_maybe_send_soft_finish_announcement", lambda *args, **kwargs: None)
 
@@ -1752,6 +1759,7 @@ def test_live_notification_suppressed_when_vip_presence_absent(monkeypatch):
     monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
     monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
     monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [])
+    monkeypatch.setattr(update_contests, "Draftkings", _StubDraftkings)
     monkeypatch.setattr(
         update_contests,
         "_resolve_vip_presence",
@@ -1807,6 +1815,7 @@ def test_completed_notification_suppressed_when_vip_presence_absent(monkeypatch)
     monkeypatch.setattr(update_contests, "_build_discord_sender", lambda: sender)
     monkeypatch.setattr(update_contests, "_sport_choices", lambda: {"nba": DummySport})
     monkeypatch.setattr(update_contests, "_warning_schedule_for", lambda _sport: [])
+    monkeypatch.setattr(update_contests, "Draftkings", _StubDraftkings)
     monkeypatch.setattr(
         update_contests,
         "_resolve_vip_presence",


### PR DESCRIPTION
## Summary
- add a DraftKings client helper to fetch contest entrants pages
- add VIP presence resolution/cache (`present`/`absent`/`unknown`) in `update_contests`
- gate lifecycle contest notifications (warning/live/completed) only when VIP presence is confidently absent
- keep fail-open behavior (`unknown` still sends) and preserve soft-finish behavior
- document VIP-gating behavior in the README

## Verification
- `uv run pytest`
- `uv run ruff format --check --exclude .ci .`
- `uv run ruff check .`
- `uv run ty check`
