### PR TITLE
[codex] Logging maintainability cleanup and deterministic VIP events

### DIFF
--- a/src/dk_results/classes/contestdatabase.py
+++ b/src/dk_results/classes/contestdatabase.py
@@ -3,9 +3,6 @@ import logging
 import sqlite3
 
 from dk_results.classes.contest import Contest
-from dk_results.logging import configure_logging
-
-configure_logging()
 
 
 class ContestDatabase:

--- a/src/dk_results/classes/draftkings.py
+++ b/src/dk_results/classes/draftkings.py
@@ -11,6 +11,7 @@ import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
@@ -109,6 +110,13 @@ class Draftkings:
         if not isinstance(name, str):
             return ""
         return "".join(c for c in unicodedata.normalize("NFD", name) if unicodedata.category(c) != "Mn")
+
+    @staticmethod
+    def _redact_url_for_logs(url: str) -> str:
+        parts = urlsplit(str(url))
+        if not parts.scheme or not parts.netloc:
+            return str(url)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
     def _lookup_salary(self, player_name: str, player_salary_map: dict[str, int] | None) -> int | None:
         if not player_salary_map or not player_name:
@@ -260,7 +268,7 @@ class Draftkings:
                         self.logger.debug("VIP %s had no roster data", user)
                         continue
 
-                    self.logger.info("Found VIP lineup for user %s", result.get("user", user))
+                    self.logger.debug("Found VIP lineup for user %s", result.get("user", user))
                     vip_lineups.append(result)
                 except Exception as e:
                     # Best-effort logging at client level
@@ -310,10 +318,11 @@ class Draftkings:
         r = self.session.get(url, timeout=timeout)
 
         ctype = r.headers.get("Content-Type", "")
+        safe_url = self._redact_url_for_logs(r.url)
         self.logger.debug(
             "download_contest_rows status=%s url=%s ctype=%s",
             r.status_code,
-            r.url,
+            safe_url,
             ctype,
         )
 

--- a/src/dk_results/classes/optimizer.py
+++ b/src/dk_results/classes/optimizer.py
@@ -3,12 +3,8 @@ from typing import Type
 
 import pulp as pl
 
-from dk_results.logging import configure_logging
-
 from .player import Player
 from .sport import Sport
-
-configure_logging()
 
 
 class Optimizer:

--- a/src/dk_results/classes/player.py
+++ b/src/dk_results/classes/player.py
@@ -4,11 +4,6 @@ import logging
 from dataclasses import InitVar, dataclass, field
 from typing import Any
 
-from dk_results.logging import configure_logging
-
-# load the logging configuration
-configure_logging()
-
 
 @dataclass
 class Player:

--- a/src/dk_results/classes/results.py
+++ b/src/dk_results/classes/results.py
@@ -188,7 +188,7 @@ class Results:
             # find lineup for friends
             if name in self.vips:
                 # if we found a VIP, add them to the VIP list
-                self.logger.info("found VIP %s", name)
+                self.logger.debug("found VIP %s", name)
                 self.vip_list.append(user)
 
             # keep track of minimum pts to cash
@@ -249,7 +249,7 @@ class Results:
 
             top_ten_cpts = list(sorted_captains)[:10]
 
-            self.logger.info("Top 10 captains:")
+            self.logger.debug("Top 10 captains:")
             for cpt in top_ten_cpts:
                 self.get_showdown_captain_percent(cpt, showdown_captains)
 
@@ -266,7 +266,7 @@ class Results:
         percent = 0.0
         num_users = len(self.users)
         percent = float(showdown_captains[player] / num_users) * 100
-        print("{}: {:0.2f}% [{}/{}]".format(player, percent, showdown_captains[player], num_users))
+        self.logger.debug("%s: %.2f%% [%d/%d]", player, percent, showdown_captains[player], num_users)
 
     def load_standings(self, filename: str) -> list[list[str]]:
         """Load standings CSV and return list."""

--- a/src/dk_results/classes/results.py
+++ b/src/dk_results/classes/results.py
@@ -266,7 +266,9 @@ class Results:
         percent = 0.0
         num_users = len(self.users)
         percent = float(showdown_captains[player] / num_users) * 100
-        self.logger.debug("%s: %.2f%% [%d/%d]", player, percent, showdown_captains[player], num_users)
+        message = "{}: {:0.2f}% [{}/{}]".format(player, percent, showdown_captains[player], num_users)
+        self.logger.debug(message)
+        print(message)
 
     def load_standings(self, filename: str) -> list[list[str]]:
         """Load standings CSV and return list."""

--- a/src/dk_results/classes/user.py
+++ b/src/dk_results/classes/user.py
@@ -2,12 +2,7 @@
 
 from dataclasses import dataclass, field
 
-from dk_results.logging import configure_logging
-
 from .lineup import Lineup
-
-# load the logging configuration
-configure_logging()
 
 
 @dataclass

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pathlib
 import sqlite3
+import time
 from collections import OrderedDict
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -50,6 +51,138 @@ CONTEST_DIR = str(repo_file("contests"))
 SALARY_DIR = str(repo_file("salary"))
 SALARY_LIMIT = 40000
 COOKIES_FILE = str(repo_file("pickled_cookies_works.txt"))
+LEGACY_VIP_EVENT_COMPAT_ENV = "DK_VIP_EVENT_COMPAT"
+LEGACY_VIP_EVENT_REMOVE_AFTER = "2026-04-30"
+LEGACY_VIP_EVENT_MAP = {
+    "vip_detection": "vip_detection_summary",
+    "vip_fetch": "vip_lineups_fetch",
+    "vip_sheet_write": "vip_lineups_summary",
+}
+
+
+def _format_log_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if value is None:
+        return "none"
+    return str(value)
+
+
+def _format_event_fields(fields: dict[str, Any]) -> str:
+    return " ".join(f"{key}={_format_log_value(value)}" for key, value in fields.items())
+
+
+def _compat_events_enabled() -> bool:
+    value = os.getenv(LEGACY_VIP_EVENT_COMPAT_ENV, "1").strip().lower()
+    return value not in {"0", "false", "no"}
+
+
+def _log_structured_info(event: str, **fields: Any) -> None:
+    body = _format_event_fields(fields)
+    logger.info("%s %s", event, body)
+
+    legacy_event = LEGACY_VIP_EVENT_MAP.get(event)
+    if legacy_event and _compat_events_enabled():
+        logger.info(
+            "%s %s deprecated=true remove_after=%s canonical=%s",
+            legacy_event,
+            body,
+            LEGACY_VIP_EVENT_REMOVE_AFTER,
+            event,
+        )
+
+
+def _log_vip_detection(
+    *,
+    sport: str,
+    contest_id: int | None,
+    requested: int,
+    found: int,
+    attempted: bool,
+    reason: str,
+) -> None:
+    _log_structured_info(
+        "vip_detection",
+        sport=sport,
+        contest_id=contest_id,
+        requested=requested,
+        found=found,
+        attempted=attempted,
+        reason=reason,
+    )
+
+
+def _log_vip_fetch(
+    *,
+    sport: str,
+    contest_id: int | None,
+    requested: int,
+    fetched: int,
+    missing_roster: int,
+    failures: int,
+    attempted: bool,
+    reason: str,
+) -> None:
+    _log_structured_info(
+        "vip_fetch",
+        sport=sport,
+        contest_id=contest_id,
+        requested=requested,
+        fetched=fetched,
+        missing_roster=missing_roster,
+        failures=failures,
+        attempted=attempted,
+        reason=reason,
+    )
+
+
+def _log_vip_sheet_write(
+    *,
+    sport: str,
+    contest_id: int | None,
+    lineups: int,
+    written: bool,
+    elapsed_ms: int,
+    reason: str,
+) -> None:
+    _log_structured_info(
+        "vip_sheet_write",
+        sport=sport,
+        contest_id=contest_id,
+        lineups=lineups,
+        written=written,
+        elapsed_ms=elapsed_ms,
+        reason=reason,
+    )
+
+
+def _log_vip_skip_events(sport_name: str, contest_id: int | None, requested: int, reason: str) -> None:
+    _log_vip_detection(
+        sport=sport_name,
+        contest_id=contest_id,
+        requested=requested,
+        found=0,
+        attempted=False,
+        reason=reason,
+    )
+    _log_vip_fetch(
+        sport=sport_name,
+        contest_id=contest_id,
+        requested=requested,
+        fetched=0,
+        missing_roster=0,
+        failures=0,
+        attempted=False,
+        reason=reason,
+    )
+    _log_vip_sheet_write(
+        sport=sport_name,
+        contest_id=contest_id,
+        lineups=0,
+        written=False,
+        elapsed_ms=0,
+        reason=reason,
+    )
 
 
 def _build_bonus_sender() -> WebhookSender | None:
@@ -94,6 +227,7 @@ def write_players_to_sheet(
     sport_name: str,
     now: datetime.datetime,
     dk: Draftkings,
+    vips: list[str],
     draft_group: int | None = None,
 ) -> None:
     """
@@ -105,6 +239,7 @@ def write_players_to_sheet(
         sport_name (str): Sport name.
         now (datetime.datetime): Current datetime.
         dk (Draftkings): Authenticated DraftKings API client.
+        vips (list[str]): VIP usernames loaded once at run start.
         draft_group (int, optional): Draft group id.
     """
     players_to_values = results.players_to_values(sport_name)
@@ -117,11 +252,51 @@ def write_players_to_sheet(
         logger.info("Writing min_cash_pts: %d", results.min_cash_pts)
         sheet.add_min_cash(results.min_cash_pts)
 
-    vips = load_vips()
     dk_id = results.contest_id
     dg = draft_group
+    fetch_requested = len(results.vip_list)
+
+    if not vips:
+        _log_vip_fetch(
+            sport=sport_name,
+            contest_id=dk_id,
+            requested=0,
+            fetched=0,
+            missing_roster=0,
+            failures=0,
+            attempted=False,
+            reason="empty_vip_set",
+        )
+        _log_vip_sheet_write(
+            sport=sport_name,
+            contest_id=dk_id,
+            lineups=0,
+            written=False,
+            elapsed_ms=0,
+            reason="empty_vip_lineups",
+        )
+        return
+
     if dg is None:
         logger.warning("No draft group found for sport, cannot pull VIP lineups from API.")
+        _log_vip_fetch(
+            sport=sport_name,
+            contest_id=dk_id,
+            requested=fetch_requested,
+            fetched=0,
+            missing_roster=fetch_requested,
+            failures=0,
+            attempted=False,
+            reason="no_draft_group",
+        )
+        _log_vip_sheet_write(
+            sport=sport_name,
+            contest_id=dk_id,
+            lineups=0,
+            written=False,
+            elapsed_ms=0,
+            reason="no_draft_group",
+        )
         return
 
     vip_entries: dict[str, dict[str, Any] | str] = {}
@@ -135,17 +310,49 @@ def write_players_to_sheet(
             "pts": vip.pts,
         }
     player_salary_map: dict[str, int] = {name: player.salary for name, player in results.players.items()}
-    vip_lineups: list[dict] = dk.get_vip_lineups(
-        dk_id,
-        dg,
-        vips,
-        vip_entries=vip_entries,
-        player_salary_map=player_salary_map,
+    fetch_failures = 0
+    fetch_reason = "not_applicable"
+    try:
+        vip_lineups: list[dict] = dk.get_vip_lineups(
+            dk_id,
+            dg,
+            vips,
+            vip_entries=vip_entries,
+            player_salary_map=player_salary_map,
+        )
+        if not vip_lineups:
+            fetch_reason = "empty_vip_lineups"
+    except Exception:
+        fetch_failures = 1
+        fetch_reason = "fetch_error"
+        vip_lineups = []
+        logger.exception("Failed VIP lineup fetch: sport=%s contest_id=%s", sport_name, dk_id)
+
+    fetched_count = len(vip_lineups)
+    _log_vip_fetch(
+        sport=sport_name,
+        contest_id=dk_id,
+        requested=fetch_requested,
+        fetched=fetched_count,
+        missing_roster=max(fetch_requested - fetched_count, 0),
+        failures=fetch_failures,
+        attempted=True,
+        reason=fetch_reason,
     )
+
     if vip_lineups:
-        logger.info("Writing API vip_lineups to sheet")
+        started = time.perf_counter()
         sheet.clear_lineups()
         sheet.write_vip_lineups(vip_lineups)
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        _log_vip_sheet_write(
+            sport=sport_name,
+            contest_id=dk_id,
+            lineups=len(vip_lineups),
+            written=True,
+            elapsed_ms=elapsed_ms,
+            reason="not_applicable",
+        )
         bonus_sender = _build_bonus_sender()
         if bonus_sender:
             try:
@@ -165,6 +372,15 @@ def write_players_to_sheet(
                     dk_id,
                     err,
                 )
+    else:
+        _log_vip_sheet_write(
+            sport=sport_name,
+            contest_id=dk_id,
+            lineups=0,
+            written=False,
+            elapsed_ms=0,
+            reason="empty_vip_lineups",
+        )
 
 
 def write_non_cashing_info(sheet: DfsSheetService, results: Results) -> None:
@@ -210,12 +426,14 @@ def write_train_info(sheet: DfsSheetService, results: Results) -> None:
     """
     if results and results.users:
         trainfinder = TrainFinder(results.users)
-        logger.info("total users: %d", trainfinder.get_total_users())
+        total_users = trainfinder.get_total_users()
+        users_above_salary = trainfinder.get_total_users_above_salary(SALARY_LIMIT)
         logger.info(
-            f"total users above salary ${SALARY_LIMIT}: %d",
-            trainfinder.get_total_users_above_salary(SALARY_LIMIT),
+            "train_summary total_users=%d salary_limit=%d users_above_salary=%d",
+            total_users,
+            SALARY_LIMIT,
+            users_above_salary,
         )
-        logger.info(f"total scores above salary ${SALARY_LIMIT}")
 
         trains: dict[str, dict[str, Any]] = trainfinder.get_users_above_salary_spent(SALARY_LIMIT)
         delete_keys = [key for key in trains if trains[key]["count"] == 1]
@@ -227,9 +445,9 @@ def write_train_info(sheet: DfsSheetService, results: Results) -> None:
         info: list[list[Any]] = [
             ["Rank", "Users", "Score", "PMR"],
         ]
-        for k, v in sorted_trains.items():
+        for v in sorted_trains.values():
             row = [v["rank"], v["count"], v["pts"], v["pmr"]]
-            logger.info(f"Users: {v['count']} Score: {v['pts']} PMR: {v['pmr']} Lineup: {v['lineup']}")
+            logger.debug("train users=%s score=%s pmr=%s lineup=%s", v["count"], v["pts"], v["pmr"], v["lineup"])
             lineupobj = v["lineup"]
             if lineupobj:
                 row.extend([player.name for player in lineupobj.lineup])
@@ -262,9 +480,10 @@ def process_sport(
     result = contest_database.get_live_contest(sport_obj.name, sport_obj.sheet_min_entry_fee, sport_obj.keyword)
     if not result:
         logger.warning("There are no live contests for %s! Moving on.", sport_name)
+        _log_vip_skip_events(sport_name, None, len(vips), "not_applicable")
         return None
 
-    dk_id, name, draft_group, positions_paid, start_date = result
+    dk_id, name, draft_group, positions_paid, _start_date = result
     fn = os.path.join(SALARY_DIR, f"DKSalaries_{sport_name}_{now:%A}.csv")
     logger.debug(args)
     dk = Draftkings()
@@ -280,6 +499,7 @@ def process_sport(
             "Contest standings download failed or was empty for dk_id=%s; skipping.",
             dk_id,
         )
+        _log_vip_skip_events(sport_name, int(dk_id), len(vips), "standings_unavailable")
         return None
 
     sheet = build_dfs_sheet_service(sport_name)
@@ -294,6 +514,14 @@ def process_sport(
     )
     results.name = name
     results.positions_paid = positions_paid
+    _log_vip_detection(
+        sport=sport_name,
+        contest_id=int(dk_id),
+        requested=len(vips),
+        found=len(results.vip_list),
+        attempted=True,
+        reason="empty_vip_set" if not vips else "not_applicable",
+    )
 
     try:
         if (sport_obj.allow_optimizer is False) or (not args.nolineups):
@@ -328,7 +556,7 @@ def process_sport(
         logger.error(error)
         logger.error("Error in optimal lineup")
 
-    write_players_to_sheet(sheet, results, sport_name, now, dk, draft_group)
+    write_players_to_sheet(sheet, results, sport_name, now, dk, vips, draft_group)
     write_non_cashing_info(sheet, results)
     write_train_info(sheet, results)
     return int(dk_id)

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -368,7 +368,6 @@ def main() -> None:
     """
     load_dotenv()
     load_and_apply_settings()
-    configure_logging()
 
     parser = argparse.ArgumentParser()
     sportz: list[SportType] = Sport.__subclasses__()
@@ -387,7 +386,7 @@ def main() -> None:
         action="store_false",
         help="If true, will not print VIP lineups",
     )
-    parser.add_argument("-v", "--verbose", help="Increase verbosity")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Increase verbosity")
     parser.add_argument(
         "--snapshot-out",
         help="Optional path to write a multi-sport snapshot envelope for selected contests.",
@@ -399,6 +398,7 @@ def main() -> None:
         help="Standings row limit used for snapshot export output.",
     )
     args = parser.parse_args()
+    configure_logging(level_override="DEBUG" if args.verbose else None)
     contest_database = ContestDatabase(str(state.contests_db_path()))
     vips = load_vips()
     now = datetime.datetime.now(ZoneInfo("America/New_York"))

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -455,6 +455,79 @@ def write_train_info(sheet: DfsSheetService, results: Results) -> None:
         sheet.add_train_info(info)
 
 
+def _build_results(
+    *,
+    sport_obj: SportType,
+    contest_id: int,
+    salary_csv: str,
+    positions_paid: int | None,
+    standings_rows: list[list[str]],
+    vips: list[str],
+    contest_name: str,
+) -> Results:
+    logger.debug("Creating Results object Results(%s, %s, %s)", sport_obj.name, contest_id, salary_csv)
+    results = Results(
+        sport_obj,
+        contest_id,
+        salary_csv,
+        positions_paid,
+        standings_rows=standings_rows,
+        vips=vips,
+    )
+    results.name = contest_name
+    results.positions_paid = positions_paid
+    return results
+
+
+def _maybe_write_optimal_lineup(
+    *,
+    sheet: DfsSheetService,
+    results: Results,
+    sport_obj: SportType,
+    args: argparse.Namespace,
+    sport_name: str,
+) -> None:
+    try:
+        if (sport_obj.allow_optimizer is False) or (not args.nolineups):
+            logger.info("Skipping optimal lineup for %s", sport_name)
+            return
+
+        optimizer = Optimizer(sport_obj, results.get_players())
+        optimized_players = optimizer.get_optimal_lineup()
+        if optimized_players:
+            optimized_players.sort(key=lambda x: (sport_obj.positions.index(x.pos), x.name))
+        if not optimized_players:
+            return
+
+        optimized_info = [
+            ["Pos", "Name", "Salary", "Pts", "Value", "Own%"],
+        ]
+        for player in optimized_players:
+            row = [
+                player.pos,
+                player.name,
+                player.salary,
+                player.fpts,
+                player.value,
+                player.ownership,
+            ]
+            logger.info(
+                "Player [%s]: %s Score: %s Salary: %s Value %s Own: %s",
+                player.pos,
+                player.name,
+                player.fpts,
+                player.salary,
+                player.value,
+                player.ownership,
+            )
+            optimized_info.append(row)
+        sheet.add_optimal_lineup(optimized_info)
+        logger.debug(optimized_players)
+    except Exception as error:
+        logger.error(error)
+        logger.error("Error in optimal lineup")
+
+
 def process_sport(
     sport_name: str,
     choices: dict[str, SportType],
@@ -503,17 +576,15 @@ def process_sport(
         return None
 
     sheet = build_dfs_sheet_service(sport_name)
-    logger.debug("Creating Results object Results(%s, %s, %s)", sport_name, dk_id, fn)
-    results: Results = Results(
-        sport_obj,
-        dk_id,
-        fn,
-        positions_paid,
+    results = _build_results(
+        sport_obj=sport_obj,
+        contest_id=int(dk_id),
+        salary_csv=fn,
+        positions_paid=positions_paid,
         standings_rows=contest_list,
         vips=vips,
+        contest_name=name,
     )
-    results.name = name
-    results.positions_paid = positions_paid
     _log_vip_detection(
         sport=sport_name,
         contest_id=int(dk_id),
@@ -523,38 +594,13 @@ def process_sport(
         reason="empty_vip_set" if not vips else "not_applicable",
     )
 
-    try:
-        if (sport_obj.allow_optimizer is False) or (not args.nolineups):
-            logger.info("Skipping optimal lineup for %s", sport_name)
-        else:
-            p = results.get_players()
-            optimizer = Optimizer(sport_obj, p)
-            optimized_players = optimizer.get_optimal_lineup()
-            if optimized_players:
-                optimized_players.sort(key=lambda x: (sport_obj.positions.index(x.pos), x.name))
-            if optimized_players:
-                optimized_info = [
-                    ["Pos", "Name", "Salary", "Pts", "Value", "Own%"],
-                ]
-                for player in optimized_players:
-                    row = [
-                        player.pos,
-                        player.name,
-                        player.salary,
-                        player.fpts,
-                        player.value,
-                        player.ownership,
-                    ]
-                    logger.info(
-                        f"Player [{player.pos}]: {player.name} Score: {player.fpts} Salary: "
-                        f"{player.salary} Value {player.value} Own: {player.ownership}"
-                    )
-                    optimized_info.append(row)
-                sheet.add_optimal_lineup(optimized_info)
-                logger.debug(optimized_players)
-    except Exception as error:
-        logger.error(error)
-        logger.error("Error in optimal lineup")
+    _maybe_write_optimal_lineup(
+        sheet=sheet,
+        results=results,
+        sport_obj=sport_obj,
+        args=args,
+        sport_name=sport_name,
+    )
 
     write_players_to_sheet(sheet, results, sport_name, now, dk, vips, draft_group)
     write_non_cashing_info(sheet, results)

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -254,7 +254,7 @@ def write_players_to_sheet(
 
     dk_id = results.contest_id
     dg = draft_group
-    fetch_requested = len(results.vip_list)
+    requested_vips = len(results.vip_list)
 
     if not vips:
         _log_vip_fetch(
@@ -282,9 +282,9 @@ def write_players_to_sheet(
         _log_vip_fetch(
             sport=sport_name,
             contest_id=dk_id,
-            requested=fetch_requested,
+            requested=requested_vips,
             fetched=0,
-            missing_roster=fetch_requested,
+            missing_roster=requested_vips,
             failures=0,
             attempted=False,
             reason="no_draft_group",
@@ -309,6 +309,8 @@ def write_players_to_sheet(
             "rank": vip.rank,
             "pts": vip.pts,
         }
+    fetch_requested = len(vip_entries) if vip_entries else requested_vips
+
     player_salary_map: dict[str, int] = {name: player.salary for name, player in results.players.items()}
     fetch_failures = 0
     fetch_reason = "not_applicable"
@@ -379,7 +381,7 @@ def write_players_to_sheet(
             lineups=0,
             written=False,
             elapsed_ms=0,
-            reason="empty_vip_lineups",
+            reason=fetch_reason,
         )
 
 
@@ -576,15 +578,20 @@ def process_sport(
         return None
 
     sheet = build_dfs_sheet_service(sport_name)
-    results = _build_results(
-        sport_obj=sport_obj,
-        contest_id=int(dk_id),
-        salary_csv=fn,
-        positions_paid=positions_paid,
-        standings_rows=contest_list,
-        vips=vips,
-        contest_name=name,
-    )
+    try:
+        results = _build_results(
+            sport_obj=sport_obj,
+            contest_id=int(dk_id),
+            salary_csv=fn,
+            positions_paid=positions_paid,
+            standings_rows=contest_list,
+            vips=vips,
+            contest_name=name,
+        )
+    except Exception:
+        logger.exception("Failed to construct Results: sport=%s contest_id=%s", sport_name, dk_id)
+        _log_vip_skip_events(sport_name, int(dk_id), len(vips), "results_unavailable")
+        return None
     _log_vip_detection(
         sport=sport_name,
         contest_id=int(dk_id),

--- a/src/dk_results/logging.py
+++ b/src/dk_results/logging.py
@@ -9,9 +9,23 @@ NOISY_LIBRARY_LOGGERS = ("googleapiclient.discovery", "urllib3", "rookie.browser
 _HANDLER_MARKER = "_dk_results_configured_handler"
 
 
-def _resolve_level(default: str = "DEBUG") -> int:
-    level_name = os.getenv("LOG_LEVEL", default).upper()
-    return getattr(logging, level_name, logging.DEBUG)
+def _default_level() -> int:
+    return logging.DEBUG if os.getenv("DK_PLATFORM", "").strip().lower() == "pi" else logging.INFO
+
+
+def _resolve_level(level_override: str | int | None = None) -> int:
+    if level_override is not None:
+        if isinstance(level_override, int):
+            return level_override
+        level_name = str(level_override).upper()
+        return getattr(logging, level_name, _default_level())
+
+    env_level = os.getenv("LOG_LEVEL")
+    if env_level:
+        level_name = env_level.upper()
+        return getattr(logging, level_name, _default_level())
+
+    return _default_level()
 
 
 def _configure_library_log_levels() -> None:
@@ -19,11 +33,11 @@ def _configure_library_log_levels() -> None:
         logging.getLogger(logger_name).setLevel(logging.INFO)
 
 
-def configure_logging() -> logging.Logger:
+def configure_logging(level_override: str | int | None = None) -> logging.Logger:
     logger = logging.getLogger()
     for handler in logger.handlers:
         if getattr(handler, _HANDLER_MARKER, False):
-            logger.setLevel(_resolve_level())
+            logger.setLevel(_resolve_level(level_override))
             _configure_library_log_levels()
             return logger
 
@@ -32,6 +46,6 @@ def configure_logging() -> logging.Logger:
         handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s"))
         setattr(handler, _HANDLER_MARKER, True)
         logger.addHandler(handler)
-    logger.setLevel(_resolve_level())
+    logger.setLevel(_resolve_level(level_override))
     _configure_library_log_levels()
     return logger

--- a/tests/classes/test_draftkings.py
+++ b/tests/classes/test_draftkings.py
@@ -270,10 +270,7 @@ def test_get_vip_lineups_handles_worker_exception(monkeypatch):
 
 def test_download_contest_rows_html_returns_none():
     response = _Response(headers={"Content-Type": "text/html"})
-    response.url = (
-        "https://example.test/contest/export?"
-        "X-Amz-Security-Token=secret-token&X-Amz-Signature=abcdef123456"
-    )
+    response.url = "https://example.test/contest/export?X-Amz-Security-Token=secret-token&X-Amz-Signature=abcdef123456"
     session = _Session(response)
     dk = Draftkings(session=session)
 
@@ -282,10 +279,7 @@ def test_download_contest_rows_html_returns_none():
 
 def test_download_contest_rows_redacts_signed_url_in_logs(caplog):
     response = _Response(headers={"Content-Type": "text/html"})
-    response.url = (
-        "https://example.test/contest/export?"
-        "X-Amz-Security-Token=secret-token&X-Amz-Signature=abcdef123456"
-    )
+    response.url = "https://example.test/contest/export?X-Amz-Security-Token=secret-token&X-Amz-Signature=abcdef123456"
     session = _Session(response)
     dk = Draftkings(session=session)
 

--- a/tests/classes/test_draftkings.py
+++ b/tests/classes/test_draftkings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -269,10 +270,31 @@ def test_get_vip_lineups_handles_worker_exception(monkeypatch):
 
 def test_download_contest_rows_html_returns_none():
     response = _Response(headers={"Content-Type": "text/html"})
+    response.url = (
+        "https://example.test/contest/export?"
+        "X-Amz-Security-Token=secret-token&X-Amz-Signature=abcdef123456"
+    )
     session = _Session(response)
     dk = Draftkings(session=session)
 
     assert dk.download_contest_rows(1) is None
+
+
+def test_download_contest_rows_redacts_signed_url_in_logs(caplog):
+    response = _Response(headers={"Content-Type": "text/html"})
+    response.url = (
+        "https://example.test/contest/export?"
+        "X-Amz-Security-Token=secret-token&X-Amz-Signature=abcdef123456"
+    )
+    session = _Session(response)
+    dk = Draftkings(session=session)
+
+    with caplog.at_level(logging.DEBUG, logger="Draftkings"):
+        assert dk.download_contest_rows(1) is None
+
+    assert "X-Amz-Security-Token" not in caplog.text
+    assert "X-Amz-Signature" not in caplog.text
+    assert "url=https://example.test/contest/export" in caplog.text
 
 
 def test_download_contest_rows_bad_zip_returns_none():

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -75,6 +75,16 @@ class _FakeDraftkings:
         return []
 
 
+class _FakeDraftkingsNoStandings(_FakeDraftkings):
+    def download_contest_rows(self, *_args, **_kwargs):
+        return None
+
+
+class _FakeDraftkingsWithVipLineups(_FakeDraftkings):
+    def get_vip_lineups(self, *_args, **_kwargs):
+        return [{"user": "UserA", "players": []}]
+
+
 class _FakeSheet:
     def __init__(self):
         self.players = []
@@ -110,6 +120,21 @@ class _FakeSheet:
         return None
 
 
+def _event_messages(caplog, event_name: str) -> list[str]:
+    return [record.message for record in caplog.records if record.message.startswith(f"{event_name} ")]
+
+
+def _parse_event_fields(message: str) -> dict[str, str]:
+    parts = message.split()[1:]
+    out: dict[str, str] = {}
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        out[key] = value
+    return out
+
+
 def test_process_sport_parses_player_stats_only_rows_and_skips_blank_users(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
@@ -139,6 +164,94 @@ def test_process_sport_parses_player_stats_only_rows_and_skips_blank_users(monke
     # Blank core row should not create phantom users in db_main path.
     assert observed["users"] == 1
     assert contest_id == 123
+
+
+def test_process_sport_emits_deterministic_vip_events_for_standings_skip(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsNoStandings)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        contest_id = db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA"],
+        )
+
+    assert contest_id is None
+    detection = _event_messages(caplog, "vip_detection")
+    fetch = _event_messages(caplog, "vip_fetch")
+    sheet_write = _event_messages(caplog, "vip_sheet_write")
+    assert len(detection) == 1
+    assert len(fetch) == 1
+    assert len(sheet_write) == 1
+    assert _parse_event_fields(detection[0])["reason"] == "standings_unavailable"
+    assert _parse_event_fields(fetch[0])["attempted"] == "false"
+    assert _parse_event_fields(sheet_write[0])["written"] == "false"
+
+
+def test_process_sport_emits_deterministic_vip_events_on_happy_path(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsWithVipLineups)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        contest_id = db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA"],
+        )
+
+    assert contest_id == 123
+    detection = _event_messages(caplog, "vip_detection")
+    fetch = _event_messages(caplog, "vip_fetch")
+    sheet_write = _event_messages(caplog, "vip_sheet_write")
+    assert len(detection) == 1
+    assert len(fetch) == 1
+    assert len(sheet_write) == 1
+
+    detection_fields = _parse_event_fields(detection[0])
+    fetch_fields = _parse_event_fields(fetch[0])
+    sheet_fields = _parse_event_fields(sheet_write[0])
+    assert detection_fields["requested"] == "1"
+    assert detection_fields["found"] == "1"
+    assert detection_fields["attempted"] == "true"
+    assert fetch_fields["requested"] == "1"
+    assert fetch_fields["fetched"] == "1"
+    assert fetch_fields["attempted"] == "true"
+    assert sheet_fields["written"] == "true"
+    assert sheet_fields["lineups"] == "1"
+
+
+def test_vip_event_compatibility_mode(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DK_VIP_EVENT_COMPAT", "1")
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsWithVipLineups)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA"],
+        )
+
+    assert len(_event_messages(caplog, "vip_detection_summary")) == 1
+    assert len(_event_messages(caplog, "vip_lineups_fetch")) == 1
+    assert len(_event_messages(caplog, "vip_lineups_summary")) == 1
+    assert "remove_after=2026-04-30" in caplog.text
 
 
 def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):
@@ -279,6 +392,45 @@ def test_main_verbose_uses_explicit_logging_override(monkeypatch, tmp_path):
     db_main.main()
 
     assert observed == ["DEBUG"]
+
+
+def test_main_loads_vips_once_per_invocation(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
+    monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
+    monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
+    monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+
+    calls = {"load_vips": 0}
+
+    def _load_vips_once():
+        calls["load_vips"] += 1
+        return ["UserA"]
+
+    process_vip_args: list[list[str]] = []
+
+    def _fake_process_sport(_sport_name, _choices, _db, _now, _args, vips):
+        process_vip_args.append(list(vips))
+        return None
+
+    monkeypatch.setattr(db_main, "load_vips", _load_vips_once)
+    monkeypatch.setattr(db_main, "process_sport", _fake_process_sport)
+    monkeypatch.setattr(
+        db_main.argparse.ArgumentParser,
+        "parse_args",
+        lambda _self: Namespace(
+            sport=["NFL", "GOLF"],
+            nolineups=False,
+            verbose=False,
+            snapshot_out=None,
+            standings_limit=123,
+        ),
+    )
+
+    db_main.main()
+
+    assert calls["load_vips"] == 1
+    assert process_vip_args == [["UserA"], ["UserA"]]
 
 
 def test_write_snapshot_payload_is_byte_stable(tmp_path):

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -62,6 +62,11 @@ class _FakeContestDb:
         )
 
 
+class _FakeContestDbNoLive:
+    def get_live_contest(self, *_args, **_kwargs):
+        return None
+
+
 class _FakeDraftkings:
     def download_salary_csv(self, _sport: str, _draft_group: int, filename: str) -> None:
         path = Path(filename)
@@ -166,6 +171,26 @@ def test_process_sport_parses_player_stats_only_rows_and_skips_blank_users(monke
     assert contest_id == 123
 
 
+def test_process_sport_handles_no_live_contest(monkeypatch, caplog):
+    with caplog.at_level(logging.INFO):
+        contest_id = db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDbNoLive(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            Namespace(nolineups=False),
+            ["UserA"],
+        )
+
+    assert contest_id is None
+    detection = _event_messages(caplog, "vip_detection")
+    fetch = _event_messages(caplog, "vip_fetch")
+    sheet_write = _event_messages(caplog, "vip_sheet_write")
+    assert len(detection) == 1
+    assert len(fetch) == 1
+    assert len(sheet_write) == 1
+
+
 def test_process_sport_emits_deterministic_vip_events_for_standings_skip(monkeypatch, tmp_path, caplog):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsNoStandings)
@@ -192,6 +217,25 @@ def test_process_sport_emits_deterministic_vip_events_for_standings_skip(monkeyp
     assert _parse_event_fields(detection[0])["reason"] == "standings_unavailable"
     assert _parse_event_fields(fetch[0])["attempted"] == "false"
     assert _parse_event_fields(sheet_write[0])["written"] == "false"
+
+
+def test_process_sport_logs_optimizer_skip(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA"],
+        )
+
+    assert "Skipping optimal lineup for NFL" in caplog.text
 
 
 def test_process_sport_emits_deterministic_vip_events_on_happy_path(monkeypatch, tmp_path, caplog):

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from argparse import Namespace
 from collections import OrderedDict
 from pathlib import Path
@@ -184,6 +185,37 @@ def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):
     assert payload["sports"]["golf"]["truncation"]["limit"] == 123
     assert payload["generated_at"].endswith("Z")
     assert payload["snapshot_at"].endswith("Z")
+
+
+def test_main_verbose_enables_debug_without_mutating_log_level_env(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
+    monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
+    monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
+    monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "load_vips", lambda: [])
+    monkeypatch.setattr(db_main, "process_sport", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        db_main.argparse.ArgumentParser,
+        "parse_args",
+        lambda _self: Namespace(
+            sport=["NFL"],
+            nolineups=False,
+            verbose=True,
+            snapshot_out=None,
+            standings_limit=123,
+        ),
+    )
+
+    root = logging.getLogger()
+    root.setLevel(logging.WARNING)
+    root.handlers.clear()
+
+    db_main.main()
+
+    assert root.level == logging.DEBUG
+    assert db_main.os.environ["LOG_LEVEL"] == "INFO"
 
 
 def test_write_snapshot_payload_is_byte_stable(tmp_path):

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -51,6 +51,51 @@ def _standings_rows() -> list[list[str]]:
     ]
 
 
+def _standings_rows_with_missing_vip_entry() -> list[list[str]]:
+    return [
+        [
+            "Rank",
+            "EntryId",
+            "EntryName",
+            "TimeRemaining",
+            "Points",
+            "Lineup",
+            "",
+            "Player",
+            "Roster Position",
+            "%Drafted",
+            "FPTS",
+        ],
+        [
+            "1",
+            "111",
+            "UserA",
+            "0",
+            "120",
+            "QB Tom Brady RB Derrick Henry",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ],
+        [
+            "2",
+            "",
+            "UserB",
+            "0",
+            "110",
+            "QB Tom Brady RB Derrick Henry",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ],
+        ["", "", "", "", "", "", "", "Tom Brady", "QB", "50.00%", "20"],
+    ]
+
+
 class _FakeContestDb:
     def get_live_contest(self, *_args, **_kwargs):
         return (
@@ -88,6 +133,22 @@ class _FakeDraftkingsNoStandings(_FakeDraftkings):
 class _FakeDraftkingsWithVipLineups(_FakeDraftkings):
     def get_vip_lineups(self, *_args, **_kwargs):
         return [{"user": "UserA", "players": []}]
+
+
+class _FakeDraftkingsFetchError(_FakeDraftkings):
+    def get_vip_lineups(self, *_args, **_kwargs):
+        raise RuntimeError("fetch failed")
+
+
+class _FakeDraftkingsTrackVipEntries(_FakeDraftkings):
+    captured_vip_entries: dict[str, dict[str, object] | str] = {}
+
+    def download_contest_rows(self, *_args, **_kwargs):
+        return _standings_rows_with_missing_vip_entry()
+
+    def get_vip_lineups(self, *_args, **kwargs):
+        type(self).captured_vip_entries = kwargs.get("vip_entries", {})
+        return []
 
 
 class _FakeSheet:
@@ -217,6 +278,86 @@ def test_process_sport_emits_deterministic_vip_events_for_standings_skip(monkeyp
     assert _parse_event_fields(detection[0])["reason"] == "standings_unavailable"
     assert _parse_event_fields(fetch[0])["attempted"] == "false"
     assert _parse_event_fields(sheet_write[0])["written"] == "false"
+
+
+def test_process_sport_emits_fetch_error_reason_to_fetch_and_sheet_events(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsFetchError)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        contest_id = db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA"],
+        )
+
+    assert contest_id == 123
+    fetch = _event_messages(caplog, "vip_fetch")
+    sheet_write = _event_messages(caplog, "vip_sheet_write")
+    assert len(fetch) == 1
+    assert len(sheet_write) == 1
+    assert _parse_event_fields(fetch[0])["reason"] == "fetch_error"
+    assert _parse_event_fields(sheet_write[0])["reason"] == "fetch_error"
+    assert _parse_event_fields(fetch[0])["attempted"] == "true"
+    assert _parse_event_fields(sheet_write[0])["written"] == "false"
+
+
+def test_vip_fetch_requested_uses_filtered_entry_keys(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsTrackVipEntries)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+    _FakeDraftkingsTrackVipEntries.captured_vip_entries = {}
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        contest_id = db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA", "UserB"],
+        )
+
+    assert contest_id == 123
+    assert len(_FakeDraftkingsTrackVipEntries.captured_vip_entries) == 1
+    fetch = _event_messages(caplog, "vip_fetch")
+    assert len(fetch) == 1
+    assert _parse_event_fields(fetch[0])["requested"] == "1"
+
+
+def test_process_sport_emits_vip_events_when_results_build_fails(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
+    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
+    monkeypatch.setattr(db_main, "_build_results", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    args = Namespace(nolineups=False)
+    with caplog.at_level(logging.INFO):
+        contest_id = db_main.process_sport(
+            "NFL",
+            {"NFL": NFLSport},
+            _FakeContestDb(),
+            datetime.datetime(2026, 2, 14, 12, 0, 0),
+            args,
+            ["UserA"],
+        )
+
+    assert contest_id is None
+    detection = _event_messages(caplog, "vip_detection")
+    fetch = _event_messages(caplog, "vip_fetch")
+    sheet_write = _event_messages(caplog, "vip_sheet_write")
+    assert len(detection) == 1
+    assert len(fetch) == 1
+    assert len(sheet_write) == 1
+    assert _parse_event_fields(detection[0])["reason"] == "results_unavailable"
+    assert _parse_event_fields(fetch[0])["reason"] == "results_unavailable"
+    assert _parse_event_fields(sheet_write[0])["reason"] == "results_unavailable"
 
 
 def test_process_sport_logs_optimizer_skip(monkeypatch, tmp_path, caplog):

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -218,6 +218,69 @@ def test_main_verbose_enables_debug_without_mutating_log_level_env(monkeypatch, 
     assert db_main.os.environ["LOG_LEVEL"] == "INFO"
 
 
+def test_main_verbose_flag_is_boolean(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
+    monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
+    monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
+    monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "load_vips", lambda: [])
+    monkeypatch.setattr(db_main, "process_sport", lambda *_args, **_kwargs: None)
+
+    observed: dict[str, str | None] = {"action": None}
+    original_add_argument = db_main.argparse.ArgumentParser.add_argument
+
+    def _capture_add_argument(parser, *names, **kwargs):
+        if "--verbose" in names:
+            observed["action"] = kwargs.get("action")
+        return original_add_argument(parser, *names, **kwargs)
+
+    monkeypatch.setattr(db_main.argparse.ArgumentParser, "add_argument", _capture_add_argument)
+    monkeypatch.setattr(
+        db_main.argparse.ArgumentParser,
+        "parse_args",
+        lambda _self: Namespace(
+            sport=["NFL"],
+            nolineups=False,
+            verbose=False,
+            snapshot_out=None,
+            standings_limit=123,
+        ),
+    )
+
+    db_main.main()
+
+    assert observed["action"] == "store_true"
+
+
+def test_main_verbose_uses_explicit_logging_override(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
+    monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
+    monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
+    monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "load_vips", lambda: [])
+    monkeypatch.setattr(db_main, "process_sport", lambda *_args, **_kwargs: None)
+
+    observed: list[str | int | None] = []
+    monkeypatch.setattr(db_main, "configure_logging", lambda level_override=None: observed.append(level_override))
+    monkeypatch.setattr(
+        db_main.argparse.ArgumentParser,
+        "parse_args",
+        lambda _self: Namespace(
+            sport=["NFL"],
+            nolineups=False,
+            verbose=True,
+            snapshot_out=None,
+            standings_limit=123,
+        ),
+    )
+
+    db_main.main()
+
+    assert observed == ["DEBUG"]
+
+
 def test_write_snapshot_payload_is_byte_stable(tmp_path):
     out = tmp_path / "stable.json"
     payload = OrderedDict(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,7 @@
+import importlib
 import logging
+import os
+import sys
 
 import pytest
 
@@ -38,9 +41,38 @@ def test_configure_logging_applies_levels_and_idempotent_handler(monkeypatch):
     assert logging.getLogger("googleapiclient.discovery").level == logging.INFO
     assert logging.getLogger("urllib3").level == logging.INFO
 
-    logger = app_logging.configure_logging()
 
-    assert logger is root
-    assert len(root.handlers) == 1
-    assert logging.getLogger("googleapiclient.discovery").level == logging.INFO
-    assert logging.getLogger("urllib3").level == logging.INFO
+def test_configure_logging_honors_level_override_without_env_mutation(monkeypatch):
+    root = logging.getLogger()
+    root.handlers.clear()
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.setenv("DK_PLATFORM", "linux")
+
+    app_logging.configure_logging(level_override="WARNING")
+
+    assert root.level == logging.WARNING
+    assert "LOG_LEVEL" not in os.environ
+
+
+def test_importing_non_entrypoint_modules_does_not_call_configure_logging(monkeypatch):
+    calls = {"count": 0}
+
+    def _fake_configure_logging(*_args, **_kwargs):
+        calls["count"] += 1
+        return logging.getLogger()
+
+    monkeypatch.setattr(app_logging, "configure_logging", _fake_configure_logging)
+
+    module_names = [
+        "dk_results.classes.player",
+        "dk_results.classes.user",
+        "dk_results.classes.optimizer",
+        "dk_results.classes.contestdatabase",
+    ]
+    for name in module_names:
+        sys.modules.pop(name, None)
+
+    for name in module_names:
+        importlib.import_module(name)
+
+    assert calls["count"] == 0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -41,6 +41,10 @@ def test_configure_logging_applies_levels_and_idempotent_handler(monkeypatch):
     assert logging.getLogger("googleapiclient.discovery").level == logging.INFO
     assert logging.getLogger("urllib3").level == logging.INFO
 
+    logger = app_logging.configure_logging()
+    assert logger is root
+    assert len(root.handlers) == 1
+
 
 def test_configure_logging_honors_level_override_without_env_mutation(monkeypatch):
     root = logging.getLogger()
@@ -52,6 +56,17 @@ def test_configure_logging_honors_level_override_without_env_mutation(monkeypatc
 
     assert root.level == logging.WARNING
     assert "LOG_LEVEL" not in os.environ
+
+
+def test_configure_logging_defaults_to_debug_on_pi(monkeypatch):
+    root = logging.getLogger()
+    root.handlers.clear()
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.setenv("DK_PLATFORM", "pi")
+
+    app_logging.configure_logging()
+
+    assert root.level == logging.DEBUG
 
 
 def test_importing_non_entrypoint_modules_does_not_call_configure_logging(monkeypatch):


### PR DESCRIPTION
## Summary
- remove hidden logging side effects and make logging level selection explicit (`level_override -> LOG_LEVEL -> DK_PLATFORM` defaults)
- centralize canonical VIP operational events in `db_main` (`vip_detection`, `vip_fetch`, `vip_sheet_write`) with deterministic skip/error emission
- add temporary legacy event-name compatibility emission with `remove_after=2026-04-30`
- reduce operational noise by demoting parser/client internals to DEBUG and adding stable train summary keys
- redact signed query strings from DraftKings standings URL debug logs
- simplify `process_sport` flow via focused helpers while preserving behavior

## Follow-up fixes from review
- `vip_sheet_write` now mirrors `vip_fetch` failure reason (`fetch_error`)
- `vip_fetch.requested` now uses filtered VIP entries
- deterministic VIP events now emit when results construction fails (`results_unavailable`)
- added explicit tests for fetch exception semantics and results-build failure path

## Validation
- `uv run pytest -q` (401 passed)
- `uv run ruff check .`
- `uv run ruff format --check --exclude .ci .`
- `uv run ty check`
