### PR TITLE
Add SportProcessor module; slim db_main.py to thin CLI wrapper

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -11,12 +11,13 @@
 - **Locality** — what maintainers get from depth (changes concentrated in one place).
 - **Draft Group Filter** — the module (`lobby/draft_group_filter.py`) that owns all sport-specific draft-group qualification logic: tag filtering, game-type constraint, suffix matching, time constraint, and NFLShowdown deduplication. Public interface: `filter_draft_groups(groups, sport) -> list[int]`.
 - **ContestStandings** — the data structure produced by parsing a DraftKings contest's salary and standings CSVs. Owns players, users, VIP list, cash line, and non-cashing stats. Contest metadata (`contest_id`, `name`) stays with callers. Module: `classes/contest_standings.py`.
+- **SportProcessor** — the module that owns the full "process one sport, write to sheet" workflow. Public interface: `SportProcessor.run(sport_name, sport_cls) -> int`. Three injected ports: `DkPort` (DraftKings HTTP), `SheetPort` (Google Sheets, via `sheet_factory: Callable[[str], SheetPort]`), `BonusSenderPort` (Discord). `ContestDatabase` is injected directly (local-substitutable). Raises `NoLiveContestError`, `StandingsUnavailableError`, or `StandsParseError` when a sport must be skipped. Module: `sport_processor.py`.
 
 ---
 
 ## Deepening Candidates
 
-Identified 2026-05-06. #1 and #6 done. Skipping #2.
+Identified 2026-05-06. #1, #5, and #6 done. Skipping #2.
 
 ### 1. VIP Lineup Module ← **done**
 
@@ -90,7 +91,7 @@ out. Sheet formatting becomes a separate downstream concern.
 
 ---
 
-### 5. Sport-Processing Module
+### 5. Sport-Processing Module ← **done**
 
 **Files:** `cli/db_main.py` (~705 lines)
 

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -6,6 +6,7 @@ import pathlib
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from dfs_common import state
 from dfs_common.discord import WebhookSender
 
 from dk_results.classes.contestdatabase import ContestDatabase
@@ -26,11 +27,10 @@ from dk_results.sport_processor import (
     NoLiveContestError,
     SportProcessor,
     SportProcessorConfig,
-    StandsParseError,
     StandingsUnavailableError,
+    StandsParseError,
 )
 from dk_results.vip_lineups import load_vips
-from dfs_common import state
 
 logger = logging.getLogger(__name__)
 

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -132,7 +132,7 @@ def main() -> None:
     processor = SportProcessor(
         contest_db=ContestDatabase(str(state.contests_db_path())),
         dk=Draftkings(),
-        sheet_factory=build_dfs_sheet_service,
+        sheet_factory=lambda sport: build_dfs_sheet_service(sport),
         bonus_sender=_build_bonus_sender(),
         config=SportProcessorConfig(
             salary_dir=SALARY_DIR,

--- a/src/dk_results/cli/db_main.py
+++ b/src/dk_results/cli/db_main.py
@@ -3,24 +3,15 @@ import datetime
 import logging
 import os
 import pathlib
-import sqlite3
-import time
-from collections import OrderedDict
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from dfs_common import state
 from dfs_common.discord import WebhookSender
 
-from dk_results.classes.bonus_announcements import announce_vip_bonuses
-from dk_results.classes.contest_standings import ContestStandings, parse_contest_standings, players_to_values
 from dk_results.classes.contestdatabase import ContestDatabase
-from dk_results.classes.dfs_sheet_service import DfsSheetService
 from dk_results.classes.draftkings import Draftkings
-from dk_results.classes.optimizer import Optimizer
 from dk_results.classes.sheets_service import build_dfs_sheet_service
 from dk_results.classes.sport import Sport
-from dk_results.classes.trainfinder import TrainFinder
 from dk_results.config import load_and_apply_settings
 from dk_results.logging import configure_logging
 from dk_results.paths import repo_file
@@ -31,7 +22,15 @@ from dk_results.services.snapshot_exporter import (
     to_stable_json,
     to_utc_iso,
 )
-from dk_results.vip_lineups import build_vip_entries, fetch_vip_lineups, load_vips
+from dk_results.sport_processor import (
+    NoLiveContestError,
+    SportProcessor,
+    SportProcessorConfig,
+    StandsParseError,
+    StandingsUnavailableError,
+)
+from dk_results.vip_lineups import load_vips
+from dfs_common import state
 
 logger = logging.getLogger(__name__)
 
@@ -43,146 +42,11 @@ except ImportError:  # pragma: no cover
         return False
 
 
-# typing helpers
 SportType = type[Sport]
 
-# Centralized constants
 CONTEST_DIR = str(repo_file("contests"))
 SALARY_DIR = str(repo_file("salary"))
-SALARY_LIMIT = 40000
 COOKIES_FILE = str(repo_file("pickled_cookies_works.txt"))
-LEGACY_VIP_EVENT_COMPAT_ENV = "DK_VIP_EVENT_COMPAT"
-LEGACY_VIP_EVENT_REMOVE_AFTER = "2026-04-30"
-LEGACY_VIP_EVENT_MAP = {
-    "vip_detection": "vip_detection_summary",
-    "vip_fetch": "vip_lineups_fetch",
-    "vip_sheet_write": "vip_lineups_summary",
-}
-
-
-def _format_log_value(value: Any) -> str:
-    if isinstance(value, bool):
-        return str(value).lower()
-    if value is None:
-        return "none"
-    return str(value)
-
-
-def _format_event_fields(fields: dict[str, Any]) -> str:
-    return " ".join(f"{key}={_format_log_value(value)}" for key, value in fields.items())
-
-
-def _compat_events_enabled() -> bool:
-    value = os.getenv(LEGACY_VIP_EVENT_COMPAT_ENV, "1").strip().lower()
-    return value not in {"0", "false", "no"}
-
-
-def _log_structured_info(event: str, **fields: Any) -> None:
-    body = _format_event_fields(fields)
-    logger.info("%s %s", event, body)
-
-    legacy_event = LEGACY_VIP_EVENT_MAP.get(event)
-    if legacy_event and _compat_events_enabled():
-        logger.info(
-            "%s %s deprecated=true remove_after=%s canonical=%s",
-            legacy_event,
-            body,
-            LEGACY_VIP_EVENT_REMOVE_AFTER,
-            event,
-        )
-
-
-def _log_vip_detection(
-    *,
-    sport: str,
-    contest_id: int | None,
-    requested: int,
-    found: int,
-    attempted: bool,
-    reason: str,
-) -> None:
-    _log_structured_info(
-        "vip_detection",
-        sport=sport,
-        contest_id=contest_id,
-        requested=requested,
-        found=found,
-        attempted=attempted,
-        reason=reason,
-    )
-
-
-def _log_vip_fetch(
-    *,
-    sport: str,
-    contest_id: int | None,
-    requested: int,
-    fetched: int,
-    missing_roster: int,
-    failures: int,
-    attempted: bool,
-    reason: str,
-) -> None:
-    _log_structured_info(
-        "vip_fetch",
-        sport=sport,
-        contest_id=contest_id,
-        requested=requested,
-        fetched=fetched,
-        missing_roster=missing_roster,
-        failures=failures,
-        attempted=attempted,
-        reason=reason,
-    )
-
-
-def _log_vip_sheet_write(
-    *,
-    sport: str,
-    contest_id: int | None,
-    lineups: int,
-    written: bool,
-    elapsed_ms: int,
-    reason: str,
-) -> None:
-    _log_structured_info(
-        "vip_sheet_write",
-        sport=sport,
-        contest_id=contest_id,
-        lineups=lineups,
-        written=written,
-        elapsed_ms=elapsed_ms,
-        reason=reason,
-    )
-
-
-def _log_vip_skip_events(sport_name: str, contest_id: int | None, requested: int, reason: str) -> None:
-    _log_vip_detection(
-        sport=sport_name,
-        contest_id=contest_id,
-        requested=requested,
-        found=0,
-        attempted=False,
-        reason=reason,
-    )
-    _log_vip_fetch(
-        sport=sport_name,
-        contest_id=contest_id,
-        requested=requested,
-        fetched=0,
-        missing_roster=0,
-        failures=0,
-        attempted=False,
-        reason=reason,
-    )
-    _log_vip_sheet_write(
-        sport=sport_name,
-        contest_id=contest_id,
-        lineups=0,
-        written=False,
-        elapsed_ms=0,
-        reason=reason,
-    )
 
 
 def _build_bonus_sender() -> WebhookSender | None:
@@ -197,388 +61,6 @@ def _build_bonus_sender() -> WebhookSender | None:
     if not webhook:
         return None
     return WebhookSender(webhook)
-
-
-def write_players_to_sheet(
-    sheet: DfsSheetService,
-    results: ContestStandings,
-    sport_name: str,
-    now: datetime.datetime,
-    dk: Draftkings,
-    vips: list[str],
-    draft_group: int | None = None,
-    contest_id: int | None = None,
-    contest_name: str = "",
-    positions_paid: int | None = None,
-) -> None:
-    players_to_write = players_to_values(results.players, sport_name)
-    sheet.clear_standings()
-    sheet.write_players(players_to_write)
-    sheet.add_contest_details(contest_name, positions_paid)
-    logger.info("Writing players to sheet")
-    sheet.add_last_updated(now)
-    if results.min_cash_pts > 0:
-        logger.info("Writing min_cash_pts: %d", results.min_cash_pts)
-        sheet.add_min_cash(results.min_cash_pts)
-
-    dk_id = contest_id
-    dg = draft_group
-    requested_vips = len(results.vip_list)
-
-    if not vips:
-        _log_vip_fetch(
-            sport=sport_name,
-            contest_id=dk_id,
-            requested=0,
-            fetched=0,
-            missing_roster=0,
-            failures=0,
-            attempted=False,
-            reason="empty_vip_set",
-        )
-        _log_vip_sheet_write(
-            sport=sport_name,
-            contest_id=dk_id,
-            lineups=0,
-            written=False,
-            elapsed_ms=0,
-            reason="empty_vip_lineups",
-        )
-        return
-
-    if dg is None:
-        logger.warning("No draft group found for sport, cannot pull VIP lineups from API.")
-        _log_vip_fetch(
-            sport=sport_name,
-            contest_id=dk_id,
-            requested=requested_vips,
-            fetched=0,
-            missing_roster=requested_vips,
-            failures=0,
-            attempted=False,
-            reason="no_draft_group",
-        )
-        _log_vip_sheet_write(
-            sport=sport_name,
-            contest_id=dk_id,
-            lineups=0,
-            written=False,
-            elapsed_ms=0,
-            reason="no_draft_group",
-        )
-        return
-
-    if dk_id is None:
-        return
-
-    vip_entries = build_vip_entries(results.vip_list)
-    fetch_requested = len(vip_entries) if vip_entries else requested_vips
-
-    player_salary_map: dict[str, int] = {name: player.salary for name, player in results.players.items()}
-    fetch_failures = 0
-    fetch_reason = "not_applicable"
-    try:
-        raw_lineups = fetch_vip_lineups(
-            dk_id,
-            dg,
-            dk,
-            vips=vips,
-            vip_entries=vip_entries,
-            player_salary_map=player_salary_map,
-        )
-        vip_lineups = [vl.to_dict() for vl in raw_lineups]
-        if not vip_lineups:
-            fetch_reason = "empty_vip_lineups"
-    except Exception:
-        fetch_failures = 1
-        fetch_reason = "fetch_error"
-        vip_lineups = []
-        logger.exception("Failed VIP lineup fetch: sport=%s contest_id=%s", sport_name, dk_id)
-
-    fetched_count = len(vip_lineups)
-    _log_vip_fetch(
-        sport=sport_name,
-        contest_id=dk_id,
-        requested=fetch_requested,
-        fetched=fetched_count,
-        missing_roster=max(fetch_requested - fetched_count, 0),
-        failures=fetch_failures,
-        attempted=True,
-        reason=fetch_reason,
-    )
-
-    if vip_lineups:
-        started = time.perf_counter()
-        sheet.clear_lineups()
-        sheet.write_vip_lineups(vip_lineups)
-        elapsed_ms = int((time.perf_counter() - started) * 1000)
-        _log_vip_sheet_write(
-            sport=sport_name,
-            contest_id=dk_id,
-            lineups=len(vip_lineups),
-            written=True,
-            elapsed_ms=elapsed_ms,
-            reason="not_applicable",
-        )
-        bonus_sender = _build_bonus_sender()
-        if bonus_sender:
-            try:
-                with sqlite3.connect(str(state.contests_db_path())) as conn:
-                    announce_vip_bonuses(
-                        conn=conn,
-                        sport=sport_name,
-                        contest_id=dk_id,
-                        vip_lineups=vip_lineups,
-                        sender=bonus_sender,
-                        logger=logger,
-                    )
-            except sqlite3.Error as err:
-                logger.error(
-                    "Failed bonus announcement DB flow for %s (%s): %s",
-                    sport_name,
-                    dk_id,
-                    err,
-                )
-    else:
-        _log_vip_sheet_write(
-            sport=sport_name,
-            contest_id=dk_id,
-            lineups=0,
-            written=False,
-            elapsed_ms=0,
-            reason=fetch_reason,
-        )
-
-
-def write_non_cashing_info(sheet: DfsSheetService, results: ContestStandings) -> None:
-    if results.non_cashing_users > 0:
-        logger.info("Writing non_cashing info")
-        info: list[list[Any]] = [
-            ["Non-Cashing Info", ""],
-            ["Users not cashing", results.non_cashing_users],
-            ["Avg PMR Remaining", results.non_cashing_avg_pmr],
-        ]
-        if results.non_cashing_players:
-            info.append(["Top 10 Own% Remaining", ""])
-            sorted_non_cashing_players: dict[str, int] = {
-                k: v
-                for k, v in sorted(
-                    results.non_cashing_players.items(),
-                    key=lambda item: item[1],
-                    reverse=True,
-                )
-            }
-            top_ten_players = [p for p, _ in list(sorted_non_cashing_players.items())[:10]]
-            for p in top_ten_players:
-                count = results.non_cashing_players[p]
-                ownership = float(count / results.non_cashing_users)
-                info.append([p, ownership])
-        sheet.add_non_cashing_info(info)
-
-
-def write_train_info(sheet: DfsSheetService, results: ContestStandings) -> None:
-    if results and results.users:
-        trainfinder = TrainFinder(results.users)
-        total_users = trainfinder.get_total_users()
-        users_above_salary = trainfinder.get_total_users_above_salary(SALARY_LIMIT)
-        logger.info(
-            "train_summary total_users=%d salary_limit=%d users_above_salary=%d",
-            total_users,
-            SALARY_LIMIT,
-            users_above_salary,
-        )
-
-        trains: dict[str, dict[str, Any]] = trainfinder.get_users_above_salary_spent(SALARY_LIMIT)
-        delete_keys = [key for key in trains if trains[key]["count"] == 1]
-        for key in delete_keys:
-            del trains[key]
-        sorted_trains: OrderedDict[str, dict[str, Any]] = OrderedDict(
-            sorted(trains.items(), key=lambda kv: kv[1]["count"], reverse=True)[:5]
-        )
-        info: list[list[Any]] = [
-            ["Rank", "Users", "Score", "PMR"],
-        ]
-        for v in sorted_trains.values():
-            row = [v["rank"], v["count"], v["pts"], v["pmr"]]
-            logger.debug("train users=%s score=%s pmr=%s lineup=%s", v["count"], v["pts"], v["pmr"], v["lineup"])
-            lineupobj = v["lineup"]
-            if lineupobj:
-                row.extend([player.name for player in lineupobj.lineup])
-            info.append(row)
-        sheet.add_train_info(info)
-
-
-def _load_salary_rows(salary_csv: str) -> list[list[str]]:
-    import csv
-
-    with open(salary_csv, mode="r") as fp:
-        return list(csv.reader(fp, delimiter=","))
-
-
-def _build_results(
-    *,
-    sport_obj: SportType,
-    contest_id: int,
-    salary_csv: str,
-    positions_paid: int | None,
-    standings_rows: list[list[str]],
-    vips: list[str],
-    contest_name: str,
-) -> ContestStandings:
-    logger.debug("Parsing contest standings: sport=%s contest_id=%s", sport_obj.name, contest_id)
-    salary_rows = _load_salary_rows(salary_csv)
-    return parse_contest_standings(
-        sport_obj,
-        salary_rows,
-        standings_rows,
-        positions_paid=positions_paid,
-        vips=vips,
-    )
-
-
-def _maybe_write_optimal_lineup(
-    *,
-    sheet: DfsSheetService,
-    results: ContestStandings,
-    sport_obj: SportType,
-    args: argparse.Namespace,
-    sport_name: str,
-) -> None:
-    try:
-        if (sport_obj.allow_optimizer is False) or (not args.nolineups):
-            logger.info("Skipping optimal lineup for %s", sport_name)
-            return
-
-        optimizer = Optimizer(sport_obj, results.players)
-        optimized_players = optimizer.get_optimal_lineup()
-        if optimized_players:
-            optimized_players.sort(key=lambda x: (sport_obj.positions.index(x.pos), x.name))
-        if not optimized_players:
-            return
-
-        optimized_info: list[list[Any]] = [
-            ["Pos", "Name", "Salary", "Pts", "Value", "Own%"],
-        ]
-        for player in optimized_players:
-            row = [
-                player.pos,
-                player.name,
-                player.salary,
-                player.fpts,
-                player.value,
-                player.ownership,
-            ]
-            logger.info(
-                "Player [%s]: %s Score: %s Salary: %s Value %s Own: %s",
-                player.pos,
-                player.name,
-                player.fpts,
-                player.salary,
-                player.value,
-                player.ownership,
-            )
-            optimized_info.append(row)
-        sheet.add_optimal_lineup(optimized_info)
-        logger.debug(optimized_players)
-    except Exception as error:
-        logger.error(error)
-        logger.error("Error in optimal lineup")
-
-
-def process_sport(
-    sport_name: str,
-    choices: dict[str, SportType],
-    contest_database: ContestDatabase,
-    now: datetime.datetime,
-    args: argparse.Namespace,
-    vips: list[str],
-) -> int | None:
-    """
-    Process a single sport: download salary, pull contest, update sheet.
-
-    Args:
-        sport_name (str): Name of the sport.
-        choices (dict[str, type]): Dictionary mapping sport names to Sport subclasses.
-        contest_database (ContestDatabase): Contest database instance.
-        now (datetime.datetime): Current datetime.
-        args (argparse.Namespace): Parsed command-line arguments.
-        vips (list[str]): VIP usernames loaded from vips.yaml.
-    """
-    if sport_name not in choices:
-        raise Exception("Could not find matching Sport subclass")
-    sport_obj = choices[sport_name]
-    result = contest_database.get_live_contest(sport_obj.name, sport_obj.sheet_min_entry_fee, sport_obj.keyword)
-    if not result:
-        logger.warning("There are no live contests for %s! Moving on.", sport_name)
-        _log_vip_skip_events(sport_name, None, len(vips), "not_applicable")
-        return None
-
-    dk_id, name, draft_group, positions_paid, _start_date = result
-    fn = os.path.join(SALARY_DIR, f"DKSalaries_{sport_name}_{now:%A}.csv")
-    logger.debug(args)
-    dk = Draftkings()
-    if draft_group:
-        logger.info("Downloading salary file (draft_group: %d)", draft_group)
-        dk.download_salary_csv(sport_name, draft_group, fn)
-
-    contest_list: list[list[str]] | None = dk.download_contest_rows(
-        dk_id, timeout=30, cookies_dump_file=COOKIES_FILE, contest_dir=CONTEST_DIR
-    )
-    if not contest_list:
-        logger.warning(
-            "Contest standings download failed or was empty for dk_id=%s; skipping.",
-            dk_id,
-        )
-        _log_vip_skip_events(sport_name, int(dk_id), len(vips), "standings_unavailable")
-        return None
-
-    sheet = build_dfs_sheet_service(sport_name)
-    try:
-        results = _build_results(
-            sport_obj=sport_obj,
-            contest_id=int(dk_id),
-            salary_csv=fn,
-            positions_paid=positions_paid,
-            standings_rows=contest_list,
-            vips=vips,
-            contest_name=name,
-        )
-    except Exception:
-        logger.exception("Failed to parse contest standings: sport=%s contest_id=%s", sport_name, dk_id)
-        _log_vip_skip_events(sport_name, int(dk_id), len(vips), "results_unavailable")
-        return None
-    _log_vip_detection(
-        sport=sport_name,
-        contest_id=int(dk_id),
-        requested=len(vips),
-        found=len(results.vip_list),
-        attempted=True,
-        reason="empty_vip_set" if not vips else "not_applicable",
-    )
-
-    _maybe_write_optimal_lineup(
-        sheet=sheet,
-        results=results,
-        sport_obj=sport_obj,
-        args=args,
-        sport_name=sport_name,
-    )
-
-    write_players_to_sheet(
-        sheet,
-        results,
-        sport_name,
-        now,
-        dk,
-        vips,
-        draft_group,
-        contest_id=int(dk_id),
-        contest_name=name,
-        positions_paid=positions_paid,
-    )
-    write_non_cashing_info(sheet, results)
-    write_train_info(sheet, results)
-    return int(dk_id)
 
 
 def build_snapshot_payload(
@@ -646,14 +128,29 @@ def main() -> None:
     )
     args = parser.parse_args()
     configure_logging(level_override="DEBUG" if args.verbose else None)
-    contest_database = ContestDatabase(str(state.contests_db_path()))
-    vips = load_vips()
-    now = datetime.datetime.now(ZoneInfo("America/New_York"))
+
+    processor = SportProcessor(
+        contest_db=ContestDatabase(str(state.contests_db_path())),
+        dk=Draftkings(),
+        sheet_factory=build_dfs_sheet_service,
+        bonus_sender=_build_bonus_sender(),
+        config=SportProcessorConfig(
+            salary_dir=SALARY_DIR,
+            contest_dir=CONTEST_DIR,
+            cookies_file=COOKIES_FILE,
+            write_optimal_lineup=args.nolineups,
+        ),
+        now=datetime.datetime.now(ZoneInfo("America/New_York")),
+        vips=load_vips(),
+    )
+
     selected_contests: dict[str, int] = {}
     for sport_name in args.sport:
-        selected_id = process_sport(sport_name, choices, contest_database, now, args, vips)
-        if selected_id is not None:
-            selected_contests[sport_name] = selected_id
+        try:
+            contest_id = processor.run(sport_name, choices[sport_name])
+            selected_contests[sport_name] = contest_id
+        except (NoLiveContestError, StandingsUnavailableError, StandsParseError):
+            continue
 
     if args.snapshot_out:
         payload = build_snapshot_payload(

--- a/src/dk_results/sport_processor.py
+++ b/src/dk_results/sport_processor.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import csv
+import datetime
+import logging
+import os
+import sqlite3
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+import requests
+from dfs_common import state
+
+from dk_results.classes.bonus_announcements import announce_vip_bonuses
+from dk_results.classes.contest_standings import ContestStandings, parse_contest_standings, players_to_values
+from dk_results.classes.contestdatabase import ContestDatabase
+from dk_results.classes.optimizer import Optimizer
+from dk_results.classes.sport import Sport
+from dk_results.classes.trainfinder import TrainFinder
+from dk_results.vip_lineups import build_vip_entries, fetch_vip_lineups
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_VIP_EVENT_COMPAT_ENV = "DK_VIP_EVENT_COMPAT"
+_LEGACY_VIP_EVENT_REMOVE_AFTER = "2026-04-30"
+_LEGACY_VIP_EVENT_MAP = {
+    "vip_detection": "vip_detection_summary",
+    "vip_fetch": "vip_lineups_fetch",
+    "vip_sheet_write": "vip_lineups_summary",
+}
+
+
+# ── Ports ──────────────────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class DkPort(Protocol):
+    def download_salary_csv(self, sport: str, draft_group: int, filename: str) -> None: ...
+    def download_contest_rows(
+        self,
+        contest_id: int,
+        *,
+        timeout: int = 30,
+        cookies_dump_file: str | None = None,
+        contest_dir: str | None = None,
+    ) -> list[list[str]] | None: ...
+    def get_leaderboard(self, contest_id: int, *, timeout: int | None = None) -> dict[str, Any]: ...
+    def get_entry(
+        self,
+        draft_group: int,
+        entry_key: str,
+        *,
+        timeout: int | None = None,
+        session: requests.Session | None = None,
+    ) -> dict[str, Any]: ...
+    def clone_auth_to(self, target_session: requests.Session) -> None: ...
+
+
+@runtime_checkable
+class SheetPort(Protocol):
+    def clear_standings(self) -> None: ...
+    def clear_lineups(self) -> None: ...
+    def write_players(self, values: Any) -> None: ...
+    def add_contest_details(self, contest_name: str, positions_paid: int | None) -> None: ...
+    def add_last_updated(self, dt: datetime.datetime) -> None: ...
+    def add_min_cash(self, pts: float) -> None: ...
+    def write_vip_lineups(self, lineups: list[dict[str, Any]]) -> None: ...
+    def add_non_cashing_info(self, info: list[list[Any]]) -> None: ...
+    def add_train_info(self, info: list[list[Any]]) -> None: ...
+    def add_optimal_lineup(self, info: list[list[Any]]) -> None: ...
+
+
+@runtime_checkable
+class BonusSenderPort(Protocol):
+    def send_message(self, message: str) -> None: ...
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SportProcessorConfig:
+    salary_dir: str
+    contest_dir: str
+    cookies_file: str
+    salary_limit: int = 40_000
+    write_optimal_lineup: bool = True
+
+
+# ── Exceptions ─────────────────────────────────────────────────────────────────
+
+
+class NoLiveContestError(Exception):
+    pass
+
+
+class StandingsUnavailableError(Exception):
+    pass
+
+
+class StandsParseError(Exception):
+    pass
+
+
+# ── Module ─────────────────────────────────────────────────────────────────────
+
+
+class SportProcessor:
+    """
+    Coordinates the full "process one sport → write sheet" workflow.
+
+    Construction-time dependencies are injected; nothing is constructed inline.
+    One instance may be reused across multiple sports in a single run.
+
+    Ordering guarantee (enforced internally):
+      1. DB lookup → NoLiveContestError if no contest
+      2. Salary CSV download
+      3. Contest standings download → StandingsUnavailableError if empty
+      4. Parse standings → StandsParseError on failure
+      5. Sheet writes (clear → players → VIP lineups → non-cashing → train)
+      6. Bonus announcements (after VIP lineups written)
+
+    Not idempotent: sheet writes are destructive (clear then write).
+    """
+
+    def __init__(
+        self,
+        *,
+        contest_db: ContestDatabase,
+        dk: DkPort,
+        sheet_factory: Callable[[str], SheetPort],
+        bonus_sender: BonusSenderPort | None,
+        config: SportProcessorConfig,
+        now: datetime.datetime,
+        vips: list[str],
+    ) -> None:
+        self._db = contest_db
+        self._dk = dk
+        self._sheet_factory = sheet_factory
+        self._bonus_sender = bonus_sender
+        self._config = config
+        self._now = now
+        self._vips = vips
+
+    def run(self, sport_name: str, sport_cls: type[Sport]) -> int:
+        """
+        Process one sport end-to-end: DB lookup → download → parse → sheet write.
+
+        Returns the DraftKings contest_id on success.
+        Raises NoLiveContestError, StandingsUnavailableError, or StandsParseError
+        when the sport must be skipped; callers should catch and continue.
+        """
+        result = self._db.get_live_contest(sport_cls.name, sport_cls.sheet_min_entry_fee, sport_cls.keyword)
+        if not result:
+            logger.warning("There are no live contests for %s! Moving on.", sport_name)
+            self._log_vip_skip_events(sport_name, None, len(self._vips), "not_applicable")
+            raise NoLiveContestError(sport_name)
+
+        dk_id, name, draft_group, positions_paid, _start_date = result
+        fn = os.path.join(self._config.salary_dir, f"DKSalaries_{sport_name}_{self._now:%A}.csv")
+
+        if draft_group:
+            logger.info("Downloading salary file (draft_group: %d)", draft_group)
+            self._dk.download_salary_csv(sport_name, draft_group, fn)
+
+        contest_list = self._dk.download_contest_rows(
+            dk_id,
+            timeout=30,
+            cookies_dump_file=self._config.cookies_file,
+            contest_dir=self._config.contest_dir,
+        )
+        if not contest_list:
+            logger.warning("Contest standings download failed or was empty for dk_id=%s; skipping.", dk_id)
+            self._log_vip_skip_events(sport_name, int(dk_id), len(self._vips), "standings_unavailable")
+            raise StandingsUnavailableError(sport_name)
+
+        sheet = self._sheet_factory(sport_name)
+
+        try:
+            results = self._build_results(
+                sport_cls=sport_cls,
+                contest_id=int(dk_id),
+                salary_csv=fn,
+                positions_paid=positions_paid,
+                standings_rows=contest_list,
+            )
+        except Exception:
+            logger.exception("Failed to parse contest standings: sport=%s contest_id=%s", sport_name, dk_id)
+            self._log_vip_skip_events(sport_name, int(dk_id), len(self._vips), "results_unavailable")
+            raise StandsParseError(sport_name)
+
+        self._log_vip_detection(
+            sport=sport_name,
+            contest_id=int(dk_id),
+            requested=len(self._vips),
+            found=len(results.vip_list),
+            attempted=True,
+            reason="empty_vip_set" if not self._vips else "not_applicable",
+        )
+
+        self._maybe_write_optimal_lineup(sheet=sheet, results=results, sport_cls=sport_cls, sport_name=sport_name)
+        self._write_players_to_sheet(sheet, results, sport_name, int(dk_id), draft_group, name, positions_paid)
+        self._write_non_cashing_info(sheet, results)
+        self._write_train_info(sheet, results)
+
+        return int(dk_id)
+
+    # ── Private workflow steps ─────────────────────────────────────────────────
+
+    def _build_results(
+        self,
+        *,
+        sport_cls: type[Sport],
+        contest_id: int,
+        salary_csv: str,
+        positions_paid: int | None,
+        standings_rows: list[list[str]],
+    ) -> ContestStandings:
+        logger.debug("Parsing contest standings: sport=%s contest_id=%s", sport_cls.name, contest_id)
+        with open(salary_csv, mode="r") as fp:
+            salary_rows = list(csv.reader(fp, delimiter=","))
+        return parse_contest_standings(
+            sport_cls,
+            salary_rows,
+            standings_rows,
+            positions_paid=positions_paid,
+            vips=self._vips,
+        )
+
+    def _maybe_write_optimal_lineup(
+        self,
+        *,
+        sheet: SheetPort,
+        results: ContestStandings,
+        sport_cls: type[Sport],
+        sport_name: str,
+    ) -> None:
+        try:
+            if (sport_cls.allow_optimizer is False) or (not self._config.write_optimal_lineup):
+                logger.info("Skipping optimal lineup for %s", sport_name)
+                return
+
+            optimizer = Optimizer(sport_cls, results.players)
+            optimized_players = optimizer.get_optimal_lineup()
+            if optimized_players:
+                optimized_players.sort(key=lambda x: (sport_cls.positions.index(x.pos), x.name))
+            if not optimized_players:
+                return
+
+            optimized_info: list[list[Any]] = [["Pos", "Name", "Salary", "Pts", "Value", "Own%"]]
+            for player in optimized_players:
+                row = [player.pos, player.name, player.salary, player.fpts, player.value, player.ownership]
+                logger.info(
+                    "Player [%s]: %s Score: %s Salary: %s Value %s Own: %s",
+                    player.pos, player.name, player.fpts, player.salary, player.value, player.ownership,
+                )
+                optimized_info.append(row)
+            sheet.add_optimal_lineup(optimized_info)
+            logger.debug(optimized_players)
+        except Exception as error:
+            logger.error(error)
+            logger.error("Error in optimal lineup")
+
+    def _write_players_to_sheet(
+        self,
+        sheet: SheetPort,
+        results: ContestStandings,
+        sport_name: str,
+        dk_id: int,
+        draft_group: int | None,
+        contest_name: str,
+        positions_paid: int | None,
+    ) -> None:
+        sheet.clear_standings()
+        sheet.write_players(players_to_values(results.players, sport_name))
+        sheet.add_contest_details(contest_name, positions_paid)
+        logger.info("Writing players to sheet")
+        sheet.add_last_updated(self._now)
+        if results.min_cash_pts > 0:
+            logger.info("Writing min_cash_pts: %d", results.min_cash_pts)
+            sheet.add_min_cash(results.min_cash_pts)
+
+        requested_vips = len(results.vip_list)
+
+        if not self._vips:
+            self._log_vip_fetch(
+                sport=sport_name, contest_id=dk_id, requested=0, fetched=0,
+                missing_roster=0, failures=0, attempted=False, reason="empty_vip_set",
+            )
+            self._log_vip_sheet_write(
+                sport=sport_name, contest_id=dk_id, lineups=0, written=False,
+                elapsed_ms=0, reason="empty_vip_lineups",
+            )
+            return
+
+        if draft_group is None:
+            logger.warning("No draft group found for sport, cannot pull VIP lineups from API.")
+            self._log_vip_fetch(
+                sport=sport_name, contest_id=dk_id, requested=requested_vips, fetched=0,
+                missing_roster=requested_vips, failures=0, attempted=False, reason="no_draft_group",
+            )
+            self._log_vip_sheet_write(
+                sport=sport_name, contest_id=dk_id, lineups=0, written=False,
+                elapsed_ms=0, reason="no_draft_group",
+            )
+            return
+
+        vip_entries = build_vip_entries(results.vip_list)
+        fetch_requested = len(vip_entries) if vip_entries else requested_vips
+        player_salary_map: dict[str, int] = {n: p.salary for n, p in results.players.items()}
+        fetch_failures = 0
+        fetch_reason = "not_applicable"
+        try:
+            raw_lineups = fetch_vip_lineups(
+                dk_id, draft_group, self._dk,
+                vips=self._vips, vip_entries=vip_entries, player_salary_map=player_salary_map,
+            )
+            vip_lineups = [vl.to_dict() for vl in raw_lineups]
+            if not vip_lineups:
+                fetch_reason = "empty_vip_lineups"
+        except Exception:
+            fetch_failures = 1
+            fetch_reason = "fetch_error"
+            vip_lineups = []
+            logger.exception("Failed VIP lineup fetch: sport=%s contest_id=%s", sport_name, dk_id)
+
+        fetched_count = len(vip_lineups)
+        self._log_vip_fetch(
+            sport=sport_name, contest_id=dk_id, requested=fetch_requested, fetched=fetched_count,
+            missing_roster=max(fetch_requested - fetched_count, 0), failures=fetch_failures,
+            attempted=True, reason=fetch_reason,
+        )
+
+        if vip_lineups:
+            started = time.perf_counter()
+            sheet.clear_lineups()
+            sheet.write_vip_lineups(vip_lineups)
+            elapsed_ms = int((time.perf_counter() - started) * 1000)
+            self._log_vip_sheet_write(
+                sport=sport_name, contest_id=dk_id, lineups=len(vip_lineups),
+                written=True, elapsed_ms=elapsed_ms, reason="not_applicable",
+            )
+            if self._bonus_sender:
+                try:
+                    with sqlite3.connect(str(state.contests_db_path())) as conn:
+                        announce_vip_bonuses(
+                            conn=conn, sport=sport_name, contest_id=dk_id,
+                            vip_lineups=vip_lineups, sender=self._bonus_sender, logger=logger,
+                        )
+                except sqlite3.Error as err:
+                    logger.error("Failed bonus announcement DB flow for %s (%s): %s", sport_name, dk_id, err)
+        else:
+            self._log_vip_sheet_write(
+                sport=sport_name, contest_id=dk_id, lineups=0,
+                written=False, elapsed_ms=0, reason=fetch_reason,
+            )
+
+    def _write_non_cashing_info(self, sheet: SheetPort, results: ContestStandings) -> None:
+        if results.non_cashing_users > 0:
+            logger.info("Writing non_cashing info")
+            info: list[list[Any]] = [
+                ["Non-Cashing Info", ""],
+                ["Users not cashing", results.non_cashing_users],
+                ["Avg PMR Remaining", results.non_cashing_avg_pmr],
+            ]
+            if results.non_cashing_players:
+                info.append(["Top 10 Own% Remaining", ""])
+                sorted_non_cashing: dict[str, int] = {
+                    k: v for k, v in sorted(
+                        results.non_cashing_players.items(), key=lambda item: item[1], reverse=True
+                    )
+                }
+                for p, count in list(sorted_non_cashing.items())[:10]:
+                    info.append([p, float(count / results.non_cashing_users)])
+            sheet.add_non_cashing_info(info)
+
+    def _write_train_info(self, sheet: SheetPort, results: ContestStandings) -> None:
+        if not (results and results.users):
+            return
+        trainfinder = TrainFinder(results.users)
+        total_users = trainfinder.get_total_users()
+        users_above_salary = trainfinder.get_total_users_above_salary(self._config.salary_limit)
+        logger.info(
+            "train_summary total_users=%d salary_limit=%d users_above_salary=%d",
+            total_users, self._config.salary_limit, users_above_salary,
+        )
+        trains: dict[str, dict[str, Any]] = trainfinder.get_users_above_salary_spent(self._config.salary_limit)
+        for key in [k for k in trains if trains[k]["count"] == 1]:
+            del trains[key]
+        sorted_trains: OrderedDict[str, dict[str, Any]] = OrderedDict(
+            sorted(trains.items(), key=lambda kv: kv[1]["count"], reverse=True)[:5]
+        )
+        info: list[list[Any]] = [["Rank", "Users", "Score", "PMR"]]
+        for v in sorted_trains.values():
+            row = [v["rank"], v["count"], v["pts"], v["pmr"]]
+            logger.debug("train users=%s score=%s pmr=%s lineup=%s", v["count"], v["pts"], v["pmr"], v["lineup"])
+            if v["lineup"]:
+                row.extend([player.name for player in v["lineup"].lineup])
+            info.append(row)
+        sheet.add_train_info(info)
+
+    # ── Structured logging ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _format_log_value(value: Any) -> str:
+        if isinstance(value, bool):
+            return str(value).lower()
+        if value is None:
+            return "none"
+        return str(value)
+
+    @classmethod
+    def _format_event_fields(cls, fields: dict[str, Any]) -> str:
+        return " ".join(f"{k}={cls._format_log_value(v)}" for k, v in fields.items())
+
+    @staticmethod
+    def _compat_events_enabled() -> bool:
+        value = os.getenv(_LEGACY_VIP_EVENT_COMPAT_ENV, "1").strip().lower()
+        return value not in {"0", "false", "no"}
+
+    @classmethod
+    def _log_structured_info(cls, event: str, **fields: Any) -> None:
+        body = cls._format_event_fields(fields)
+        logger.info("%s %s", event, body)
+        legacy_event = _LEGACY_VIP_EVENT_MAP.get(event)
+        if legacy_event and cls._compat_events_enabled():
+            logger.info(
+                "%s %s deprecated=true remove_after=%s canonical=%s",
+                legacy_event, body, _LEGACY_VIP_EVENT_REMOVE_AFTER, event,
+            )
+
+    @classmethod
+    def _log_vip_detection(
+        cls, *, sport: str, contest_id: int | None, requested: int, found: int, attempted: bool, reason: str
+    ) -> None:
+        cls._log_structured_info(
+            "vip_detection", sport=sport, contest_id=contest_id,
+            requested=requested, found=found, attempted=attempted, reason=reason,
+        )
+
+    @classmethod
+    def _log_vip_fetch(
+        cls, *, sport: str, contest_id: int | None, requested: int, fetched: int,
+        missing_roster: int, failures: int, attempted: bool, reason: str,
+    ) -> None:
+        cls._log_structured_info(
+            "vip_fetch", sport=sport, contest_id=contest_id, requested=requested,
+            fetched=fetched, missing_roster=missing_roster, failures=failures,
+            attempted=attempted, reason=reason,
+        )
+
+    @classmethod
+    def _log_vip_sheet_write(
+        cls, *, sport: str, contest_id: int | None, lineups: int, written: bool, elapsed_ms: int, reason: str,
+    ) -> None:
+        cls._log_structured_info(
+            "vip_sheet_write", sport=sport, contest_id=contest_id,
+            lineups=lineups, written=written, elapsed_ms=elapsed_ms, reason=reason,
+        )
+
+    @classmethod
+    def _log_vip_skip_events(cls, sport_name: str, contest_id: int | None, requested: int, reason: str) -> None:
+        cls._log_vip_detection(
+            sport=sport_name, contest_id=contest_id, requested=requested,
+            found=0, attempted=False, reason=reason,
+        )
+        cls._log_vip_fetch(
+            sport=sport_name, contest_id=contest_id, requested=requested,
+            fetched=0, missing_roster=0, failures=0, attempted=False, reason=reason,
+        )
+        cls._log_vip_sheet_write(
+            sport=sport_name, contest_id=contest_id, lineups=0,
+            written=False, elapsed_ms=0, reason=reason,
+        )

--- a/src/dk_results/sport_processor.py
+++ b/src/dk_results/sport_processor.py
@@ -191,17 +191,9 @@ class SportProcessor:
             self._log_vip_skip_events(sport_name, int(dk_id), len(self._vips), "results_unavailable")
             raise StandsParseError(sport_name)
 
-        self._log_vip_detection(
-            sport=sport_name,
-            contest_id=int(dk_id),
-            requested=len(self._vips),
-            found=len(results.vip_list),
-            attempted=True,
-            reason="empty_vip_set" if not self._vips else "not_applicable",
-        )
-
         self._maybe_write_optimal_lineup(sheet=sheet, results=results, sport_cls=sport_cls, sport_name=sport_name)
-        self._write_players_to_sheet(sheet, results, sport_name, int(dk_id), draft_group, name, positions_paid)
+        self._write_standings(sheet, results, sport_name, int(dk_id), name, positions_paid)
+        self._write_vip_lineups(sheet, results, sport_name, int(dk_id), draft_group)
         self._write_non_cashing_info(sheet, results)
         self._write_train_info(sheet, results)
 
@@ -268,13 +260,12 @@ class SportProcessor:
             logger.error(error)
             logger.error("Error in optimal lineup")
 
-    def _write_players_to_sheet(
+    def _write_standings(
         self,
         sheet: SheetPort,
         results: ContestStandings,
         sport_name: str,
         dk_id: int,
-        draft_group: int | None,
         contest_name: str,
         positions_paid: int | None,
     ) -> None:
@@ -286,6 +277,23 @@ class SportProcessor:
         if results.min_cash_pts > 0:
             logger.info("Writing min_cash_pts: %d", results.min_cash_pts)
             sheet.add_min_cash(results.min_cash_pts)
+
+    def _write_vip_lineups(
+        self,
+        sheet: SheetPort,
+        results: ContestStandings,
+        sport_name: str,
+        dk_id: int,
+        draft_group: int | None,
+    ) -> None:
+        self._log_vip_detection(
+            sport=sport_name,
+            contest_id=dk_id,
+            requested=len(self._vips),
+            found=len(results.vip_list),
+            attempted=True,
+            reason="empty_vip_set" if not self._vips else "not_applicable",
+        )
 
         requested_vips = len(results.vip_list)
 

--- a/src/dk_results/sport_processor.py
+++ b/src/dk_results/sport_processor.py
@@ -254,7 +254,12 @@ class SportProcessor:
                 row = [player.pos, player.name, player.salary, player.fpts, player.value, player.ownership]
                 logger.info(
                     "Player [%s]: %s Score: %s Salary: %s Value %s Own: %s",
-                    player.pos, player.name, player.fpts, player.salary, player.value, player.ownership,
+                    player.pos,
+                    player.name,
+                    player.fpts,
+                    player.salary,
+                    player.value,
+                    player.ownership,
                 )
                 optimized_info.append(row)
             sheet.add_optimal_lineup(optimized_info)
@@ -286,24 +291,44 @@ class SportProcessor:
 
         if not self._vips:
             self._log_vip_fetch(
-                sport=sport_name, contest_id=dk_id, requested=0, fetched=0,
-                missing_roster=0, failures=0, attempted=False, reason="empty_vip_set",
+                sport=sport_name,
+                contest_id=dk_id,
+                requested=0,
+                fetched=0,
+                missing_roster=0,
+                failures=0,
+                attempted=False,
+                reason="empty_vip_set",
             )
             self._log_vip_sheet_write(
-                sport=sport_name, contest_id=dk_id, lineups=0, written=False,
-                elapsed_ms=0, reason="empty_vip_lineups",
+                sport=sport_name,
+                contest_id=dk_id,
+                lineups=0,
+                written=False,
+                elapsed_ms=0,
+                reason="empty_vip_lineups",
             )
             return
 
         if draft_group is None:
             logger.warning("No draft group found for sport, cannot pull VIP lineups from API.")
             self._log_vip_fetch(
-                sport=sport_name, contest_id=dk_id, requested=requested_vips, fetched=0,
-                missing_roster=requested_vips, failures=0, attempted=False, reason="no_draft_group",
+                sport=sport_name,
+                contest_id=dk_id,
+                requested=requested_vips,
+                fetched=0,
+                missing_roster=requested_vips,
+                failures=0,
+                attempted=False,
+                reason="no_draft_group",
             )
             self._log_vip_sheet_write(
-                sport=sport_name, contest_id=dk_id, lineups=0, written=False,
-                elapsed_ms=0, reason="no_draft_group",
+                sport=sport_name,
+                contest_id=dk_id,
+                lineups=0,
+                written=False,
+                elapsed_ms=0,
+                reason="no_draft_group",
             )
             return
 
@@ -314,8 +339,12 @@ class SportProcessor:
         fetch_reason = "not_applicable"
         try:
             raw_lineups = fetch_vip_lineups(
-                dk_id, draft_group, self._dk,
-                vips=self._vips, vip_entries=vip_entries, player_salary_map=player_salary_map,
+                dk_id,
+                draft_group,
+                self._dk,
+                vips=self._vips,
+                vip_entries=vip_entries,
+                player_salary_map=player_salary_map,
             )
             vip_lineups = [vl.to_dict() for vl in raw_lineups]
             if not vip_lineups:
@@ -328,9 +357,14 @@ class SportProcessor:
 
         fetched_count = len(vip_lineups)
         self._log_vip_fetch(
-            sport=sport_name, contest_id=dk_id, requested=fetch_requested, fetched=fetched_count,
-            missing_roster=max(fetch_requested - fetched_count, 0), failures=fetch_failures,
-            attempted=True, reason=fetch_reason,
+            sport=sport_name,
+            contest_id=dk_id,
+            requested=fetch_requested,
+            fetched=fetched_count,
+            missing_roster=max(fetch_requested - fetched_count, 0),
+            failures=fetch_failures,
+            attempted=True,
+            reason=fetch_reason,
         )
 
         if vip_lineups:
@@ -339,22 +373,34 @@ class SportProcessor:
             sheet.write_vip_lineups(vip_lineups)
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             self._log_vip_sheet_write(
-                sport=sport_name, contest_id=dk_id, lineups=len(vip_lineups),
-                written=True, elapsed_ms=elapsed_ms, reason="not_applicable",
+                sport=sport_name,
+                contest_id=dk_id,
+                lineups=len(vip_lineups),
+                written=True,
+                elapsed_ms=elapsed_ms,
+                reason="not_applicable",
             )
             if self._bonus_sender:
                 try:
                     with sqlite3.connect(str(state.contests_db_path())) as conn:
                         announce_vip_bonuses(
-                            conn=conn, sport=sport_name, contest_id=dk_id,
-                            vip_lineups=vip_lineups, sender=self._bonus_sender, logger=logger,
+                            conn=conn,
+                            sport=sport_name,
+                            contest_id=dk_id,
+                            vip_lineups=vip_lineups,
+                            sender=self._bonus_sender,
+                            logger=logger,
                         )
                 except sqlite3.Error as err:
                     logger.error("Failed bonus announcement DB flow for %s (%s): %s", sport_name, dk_id, err)
         else:
             self._log_vip_sheet_write(
-                sport=sport_name, contest_id=dk_id, lineups=0,
-                written=False, elapsed_ms=0, reason=fetch_reason,
+                sport=sport_name,
+                contest_id=dk_id,
+                lineups=0,
+                written=False,
+                elapsed_ms=0,
+                reason=fetch_reason,
             )
 
     def _write_non_cashing_info(self, sheet: SheetPort, results: ContestStandings) -> None:
@@ -368,9 +414,7 @@ class SportProcessor:
             if results.non_cashing_players:
                 info.append(["Top 10 Own% Remaining", ""])
                 sorted_non_cashing: dict[str, int] = {
-                    k: v for k, v in sorted(
-                        results.non_cashing_players.items(), key=lambda item: item[1], reverse=True
-                    )
+                    k: v for k, v in sorted(results.non_cashing_players.items(), key=lambda item: item[1], reverse=True)
                 }
                 for p, count in list(sorted_non_cashing.items())[:10]:
                     info.append([p, float(count / results.non_cashing_users)])
@@ -384,7 +428,9 @@ class SportProcessor:
         users_above_salary = trainfinder.get_total_users_above_salary(self._config.salary_limit)
         logger.info(
             "train_summary total_users=%d salary_limit=%d users_above_salary=%d",
-            total_users, self._config.salary_limit, users_above_salary,
+            total_users,
+            self._config.salary_limit,
+            users_above_salary,
         )
         trains: dict[str, dict[str, Any]] = trainfinder.get_users_above_salary_spent(self._config.salary_limit)
         for key in [k for k in trains if trains[k]["count"] == 1]:
@@ -428,7 +474,10 @@ class SportProcessor:
         if legacy_event and cls._compat_events_enabled():
             logger.info(
                 "%s %s deprecated=true remove_after=%s canonical=%s",
-                legacy_event, body, _LEGACY_VIP_EVENT_REMOVE_AFTER, event,
+                legacy_event,
+                body,
+                _LEGACY_VIP_EVENT_REMOVE_AFTER,
+                event,
             )
 
     @classmethod
@@ -436,41 +485,86 @@ class SportProcessor:
         cls, *, sport: str, contest_id: int | None, requested: int, found: int, attempted: bool, reason: str
     ) -> None:
         cls._log_structured_info(
-            "vip_detection", sport=sport, contest_id=contest_id,
-            requested=requested, found=found, attempted=attempted, reason=reason,
+            "vip_detection",
+            sport=sport,
+            contest_id=contest_id,
+            requested=requested,
+            found=found,
+            attempted=attempted,
+            reason=reason,
         )
 
     @classmethod
     def _log_vip_fetch(
-        cls, *, sport: str, contest_id: int | None, requested: int, fetched: int,
-        missing_roster: int, failures: int, attempted: bool, reason: str,
+        cls,
+        *,
+        sport: str,
+        contest_id: int | None,
+        requested: int,
+        fetched: int,
+        missing_roster: int,
+        failures: int,
+        attempted: bool,
+        reason: str,
     ) -> None:
         cls._log_structured_info(
-            "vip_fetch", sport=sport, contest_id=contest_id, requested=requested,
-            fetched=fetched, missing_roster=missing_roster, failures=failures,
-            attempted=attempted, reason=reason,
+            "vip_fetch",
+            sport=sport,
+            contest_id=contest_id,
+            requested=requested,
+            fetched=fetched,
+            missing_roster=missing_roster,
+            failures=failures,
+            attempted=attempted,
+            reason=reason,
         )
 
     @classmethod
     def _log_vip_sheet_write(
-        cls, *, sport: str, contest_id: int | None, lineups: int, written: bool, elapsed_ms: int, reason: str,
+        cls,
+        *,
+        sport: str,
+        contest_id: int | None,
+        lineups: int,
+        written: bool,
+        elapsed_ms: int,
+        reason: str,
     ) -> None:
         cls._log_structured_info(
-            "vip_sheet_write", sport=sport, contest_id=contest_id,
-            lineups=lineups, written=written, elapsed_ms=elapsed_ms, reason=reason,
+            "vip_sheet_write",
+            sport=sport,
+            contest_id=contest_id,
+            lineups=lineups,
+            written=written,
+            elapsed_ms=elapsed_ms,
+            reason=reason,
         )
 
     @classmethod
     def _log_vip_skip_events(cls, sport_name: str, contest_id: int | None, requested: int, reason: str) -> None:
         cls._log_vip_detection(
-            sport=sport_name, contest_id=contest_id, requested=requested,
-            found=0, attempted=False, reason=reason,
+            sport=sport_name,
+            contest_id=contest_id,
+            requested=requested,
+            found=0,
+            attempted=False,
+            reason=reason,
         )
         cls._log_vip_fetch(
-            sport=sport_name, contest_id=contest_id, requested=requested,
-            fetched=0, missing_roster=0, failures=0, attempted=False, reason=reason,
+            sport=sport_name,
+            contest_id=contest_id,
+            requested=requested,
+            fetched=0,
+            missing_roster=0,
+            failures=0,
+            attempted=False,
+            reason=reason,
         )
         cls._log_vip_sheet_write(
-            sport=sport_name, contest_id=contest_id, lineups=0,
-            written=False, elapsed_ms=0, reason=reason,
+            sport=sport_name,
+            contest_id=contest_id,
+            lineups=0,
+            written=False,
+            elapsed_ms=0,
+            reason=reason,
         )

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -5,9 +5,17 @@ from argparse import Namespace
 from collections import OrderedDict
 from pathlib import Path
 
+import pytest
 from classes.sport import NFLSport
 
 import dk_results.cli.db_main as db_main
+from dk_results.sport_processor import (
+    NoLiveContestError,
+    SportProcessor,
+    SportProcessorConfig,
+    StandingsUnavailableError,
+    StandsParseError,
+)
 
 
 def _salary_csv_text() -> str:
@@ -200,29 +208,45 @@ def _parse_event_fields(message: str) -> dict[str, str]:
     return out
 
 
-def test_process_sport_parses_player_stats_only_rows_and_skips_blank_users(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
-    fake_sheet = _FakeSheet()
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: fake_sheet)
-    monkeypatch.setattr(db_main, "load_vips", lambda: [])
+def _make_processor(
+    db,
+    vips,
+    *,
+    dk=None,
+    sheet=None,
+    nolineups: bool = False,
+    salary_dir: str = "",
+) -> SportProcessor:
+    if dk is None:
+        dk = _FakeDraftkings()
+    if sheet is None:
+        sheet = _FakeSheet()
+    return SportProcessor(
+        contest_db=db,
+        dk=dk,
+        sheet_factory=lambda _sport: sheet,
+        bonus_sender=None,
+        config=SportProcessorConfig(
+            salary_dir=salary_dir,
+            contest_dir=".",
+            cookies_file=".",
+            write_optimal_lineup=nolineups,
+        ),
+        now=datetime.datetime(2026, 2, 14, 12, 0, 0),
+        vips=vips,
+    )
 
+
+def test_process_sport_parses_player_stats_only_rows_and_skips_blank_users(monkeypatch, tmp_path):
+    fake_sheet = _FakeSheet()
     observed = {}
 
-    def _capture_train(_sheet, results):
+    def _capture_train(self, sheet, results):
         observed["users"] = len(results.users)
 
-    monkeypatch.setattr(db_main, "write_train_info", _capture_train)
-
-    args = Namespace(nolineups=False)
-    contest_id = db_main.process_sport(
-        "NFL",
-        {"NFL": NFLSport},
-        _FakeContestDb(),
-        datetime.datetime(2026, 2, 14, 12, 0, 0),
-        args,
-        [],
-    )
+    monkeypatch.setattr(SportProcessor, "_write_train_info", _capture_train)
+    processor = _make_processor(_FakeContestDb(), vips=[], sheet=fake_sheet, salary_dir=str(tmp_path))
+    contest_id = processor.run("NFL", NFLSport)
 
     # Player-only standings row should update ownership/fpts, so Tom Brady appears in player output.
     assert any(row[1] == "Tom Brady" for row in fake_sheet.players)
@@ -231,18 +255,12 @@ def test_process_sport_parses_player_stats_only_rows_and_skips_blank_users(monke
     assert contest_id == 123
 
 
-def test_process_sport_handles_no_live_contest(monkeypatch, caplog):
+def test_process_sport_handles_no_live_contest(caplog):
+    processor = _make_processor(_FakeContestDbNoLive(), vips=["UserA"])
     with caplog.at_level(logging.INFO):
-        contest_id = db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDbNoLive(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            Namespace(nolineups=False),
-            ["UserA"],
-        )
+        with pytest.raises(NoLiveContestError):
+            processor.run("NFL", NFLSport)
 
-    assert contest_id is None
     detection = _event_messages(caplog, "vip_detection")
     fetch = _event_messages(caplog, "vip_fetch")
     sheet_write = _event_messages(caplog, "vip_sheet_write")
@@ -251,23 +269,17 @@ def test_process_sport_handles_no_live_contest(monkeypatch, caplog):
     assert len(sheet_write) == 1
 
 
-def test_process_sport_emits_deterministic_vip_events_for_standings_skip(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsNoStandings)
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-
-    args = Namespace(nolineups=False)
+def test_process_sport_emits_deterministic_vip_events_for_standings_skip(tmp_path, caplog):
+    processor = _make_processor(
+        _FakeContestDb(),
+        vips=["UserA"],
+        dk=_FakeDraftkingsNoStandings(),
+        salary_dir=str(tmp_path),
+    )
     with caplog.at_level(logging.INFO):
-        contest_id = db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA"],
-        )
+        with pytest.raises(StandingsUnavailableError):
+            processor.run("NFL", NFLSport)
 
-    assert contest_id is None
     detection = _event_messages(caplog, "vip_detection")
     fetch = _event_messages(caplog, "vip_fetch")
     sheet_write = _event_messages(caplog, "vip_sheet_write")
@@ -280,23 +292,13 @@ def test_process_sport_emits_deterministic_vip_events_for_standings_skip(monkeyp
 
 
 def test_process_sport_emits_fetch_error_reason_to_fetch_and_sheet_events(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
     monkeypatch.setattr(
-        db_main, "fetch_vip_lineups", lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("fetch failed"))
+        "dk_results.sport_processor.fetch_vip_lineups",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("fetch failed")),
     )
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-
-    args = Namespace(nolineups=False)
+    processor = _make_processor(_FakeContestDb(), vips=["UserA"], salary_dir=str(tmp_path))
     with caplog.at_level(logging.INFO):
-        contest_id = db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA"],
-        )
+        contest_id = processor.run("NFL", NFLSport)
 
     assert contest_id == 123
     fetch = _event_messages(caplog, "vip_fetch")
@@ -310,28 +312,21 @@ def test_process_sport_emits_fetch_error_reason_to_fetch_and_sheet_events(monkey
 
 
 def test_vip_fetch_requested_uses_filtered_entry_keys(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkingsTrackVipEntries)
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-
     captured: dict = {}
 
     def _capture_fetch(*_args, vip_entries=None, **_kw):
         captured["vip_entries"] = vip_entries or {}
         return []
 
-    monkeypatch.setattr(db_main, "fetch_vip_lineups", _capture_fetch)
-
-    args = Namespace(nolineups=False)
+    monkeypatch.setattr("dk_results.sport_processor.fetch_vip_lineups", _capture_fetch)
+    processor = _make_processor(
+        _FakeContestDb(),
+        vips=["UserA", "UserB"],
+        dk=_FakeDraftkingsTrackVipEntries(),
+        salary_dir=str(tmp_path),
+    )
     with caplog.at_level(logging.INFO):
-        contest_id = db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA", "UserB"],
-        )
+        contest_id = processor.run("NFL", NFLSport)
 
     assert contest_id == 123
     assert len(captured["vip_entries"]) == 1
@@ -341,23 +336,16 @@ def test_vip_fetch_requested_uses_filtered_entry_keys(monkeypatch, tmp_path, cap
 
 
 def test_process_sport_emits_vip_events_when_results_build_fails(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-    monkeypatch.setattr(db_main, "_build_results", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
-
-    args = Namespace(nolineups=False)
+    monkeypatch.setattr(
+        SportProcessor,
+        "_build_results",
+        lambda self, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    processor = _make_processor(_FakeContestDb(), vips=["UserA"], salary_dir=str(tmp_path))
     with caplog.at_level(logging.INFO):
-        contest_id = db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA"],
-        )
+        with pytest.raises(StandsParseError):
+            processor.run("NFL", NFLSport)
 
-    assert contest_id is None
     detection = _event_messages(caplog, "vip_detection")
     fetch = _event_messages(caplog, "vip_fetch")
     sheet_write = _event_messages(caplog, "vip_sheet_write")
@@ -369,45 +357,22 @@ def test_process_sport_emits_vip_events_when_results_build_fails(monkeypatch, tm
     assert _parse_event_fields(sheet_write[0])["reason"] == "results_unavailable"
 
 
-def test_process_sport_logs_optimizer_skip(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-
-    args = Namespace(nolineups=False)
+def test_process_sport_logs_optimizer_skip(tmp_path, caplog):
+    processor = _make_processor(_FakeContestDb(), vips=["UserA"], salary_dir=str(tmp_path), nolineups=False)
     with caplog.at_level(logging.INFO):
-        db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA"],
-        )
+        processor.run("NFL", NFLSport)
 
     assert "Skipping optimal lineup for NFL" in caplog.text
 
 
 def test_process_sport_emits_deterministic_vip_events_on_happy_path(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
     monkeypatch.setattr(
-        db_main,
-        "fetch_vip_lineups",
+        "dk_results.sport_processor.fetch_vip_lineups",
         lambda *_a, **_kw: [_FakeVipLineup()],
     )
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-
-    args = Namespace(nolineups=False)
+    processor = _make_processor(_FakeContestDb(), vips=["UserA"], salary_dir=str(tmp_path))
     with caplog.at_level(logging.INFO):
-        contest_id = db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA"],
-        )
+        contest_id = processor.run("NFL", NFLSport)
 
     assert contest_id == 123
     detection = _event_messages(caplog, "vip_detection")
@@ -431,26 +396,14 @@ def test_process_sport_emits_deterministic_vip_events_on_happy_path(monkeypatch,
 
 
 def test_vip_event_compatibility_mode(monkeypatch, tmp_path, caplog):
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("DK_VIP_EVENT_COMPAT", "1")
-    monkeypatch.setattr(db_main, "Draftkings", _FakeDraftkings)
     monkeypatch.setattr(
-        db_main,
-        "fetch_vip_lineups",
+        "dk_results.sport_processor.fetch_vip_lineups",
         lambda *_a, **_kw: [_FakeVipLineup()],
     )
-    monkeypatch.setattr(db_main, "build_dfs_sheet_service", lambda _sport: _FakeSheet())
-
-    args = Namespace(nolineups=False)
+    processor = _make_processor(_FakeContestDb(), vips=["UserA"], salary_dir=str(tmp_path))
     with caplog.at_level(logging.INFO):
-        db_main.process_sport(
-            "NFL",
-            {"NFL": NFLSport},
-            _FakeContestDb(),
-            datetime.datetime(2026, 2, 14, 12, 0, 0),
-            args,
-            ["UserA"],
-        )
+        processor.run("NFL", NFLSport)
 
     assert len(_event_messages(caplog, "vip_detection_summary")) == 1
     assert len(_event_messages(caplog, "vip_lineups_fetch")) == 1
@@ -460,11 +413,11 @@ def test_vip_event_compatibility_mode(monkeypatch, tmp_path, caplog):
 
 def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):
     out = tmp_path / "snapshot.json"
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
     monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
     monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
     monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "Draftkings", lambda: object())
     monkeypatch.setattr(db_main, "load_vips", lambda: [])
     monkeypatch.setattr(
         db_main.argparse.ArgumentParser,
@@ -477,11 +430,15 @@ def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):
             standings_limit=123,
         ),
     )
-    monkeypatch.setattr(
-        db_main,
-        "process_sport",
-        lambda sport_name, *_args, **_kwargs: 111 if sport_name == "NFL" else 222,
-    )
+
+    class _FakeSportProcessor:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, sport_name, sport_cls):
+            return 111 if sport_name == "NFL" else 222
+
+    monkeypatch.setattr(db_main, "SportProcessor", _FakeSportProcessor)
 
     def _fake_snapshot(*, sport: str, contest_id: int | None, standings_limit: int):
         return {
@@ -505,14 +462,22 @@ def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):
 
 
 def test_main_verbose_enables_debug_without_mutating_log_level_env(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOG_LEVEL", "INFO")
     monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
     monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
     monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
     monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "Draftkings", lambda: object())
     monkeypatch.setattr(db_main, "load_vips", lambda: [])
-    monkeypatch.setattr(db_main, "process_sport", lambda *_args, **_kwargs: None)
+
+    class _FakeSportProcessor:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, sport_name, sport_cls):
+            return None
+
+    monkeypatch.setattr(db_main, "SportProcessor", _FakeSportProcessor)
     monkeypatch.setattr(
         db_main.argparse.ArgumentParser,
         "parse_args",
@@ -536,13 +501,21 @@ def test_main_verbose_enables_debug_without_mutating_log_level_env(monkeypatch, 
 
 
 def test_main_verbose_flag_is_boolean(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
     monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
     monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
     monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "Draftkings", lambda: object())
     monkeypatch.setattr(db_main, "load_vips", lambda: [])
-    monkeypatch.setattr(db_main, "process_sport", lambda *_args, **_kwargs: None)
+
+    class _FakeSportProcessor:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, sport_name, sport_cls):
+            return None
+
+    monkeypatch.setattr(db_main, "SportProcessor", _FakeSportProcessor)
 
     observed: dict[str, str | None] = {"action": None}
     original_add_argument = db_main.argparse.ArgumentParser.add_argument
@@ -571,13 +544,21 @@ def test_main_verbose_flag_is_boolean(monkeypatch, tmp_path):
 
 
 def test_main_verbose_uses_explicit_logging_override(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
     monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
     monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
     monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "Draftkings", lambda: object())
     monkeypatch.setattr(db_main, "load_vips", lambda: [])
-    monkeypatch.setattr(db_main, "process_sport", lambda *_args, **_kwargs: None)
+
+    class _FakeSportProcessor:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, sport_name, sport_cls):
+            return None
+
+    monkeypatch.setattr(db_main, "SportProcessor", _FakeSportProcessor)
 
     observed: list[str | int | None] = []
     monkeypatch.setattr(db_main, "configure_logging", lambda level_override=None: observed.append(level_override))
@@ -599,11 +580,11 @@ def test_main_verbose_uses_explicit_logging_override(monkeypatch, tmp_path):
 
 
 def test_main_loads_vips_once_per_invocation(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(db_main, "load_dotenv", lambda: None)
     monkeypatch.setattr(db_main, "load_and_apply_settings", lambda: None)
     monkeypatch.setattr(db_main.state, "contests_db_path", lambda: tmp_path / "contests.db")
     monkeypatch.setattr(db_main, "ContestDatabase", lambda _path: object())
+    monkeypatch.setattr(db_main, "Draftkings", lambda: object())
 
     calls = {"load_vips": 0}
 
@@ -611,14 +592,19 @@ def test_main_loads_vips_once_per_invocation(monkeypatch, tmp_path):
         calls["load_vips"] += 1
         return ["UserA"]
 
-    process_vip_args: list[list[str]] = []
+    captured_vips: list[str] = []
+    run_sports: list[str] = []
 
-    def _fake_process_sport(_sport_name, _choices, _db, _now, _args, vips):
-        process_vip_args.append(list(vips))
-        return None
+    class _FakeSportProcessor:
+        def __init__(self, *, vips, **kwargs):
+            captured_vips.extend(vips)
+
+        def run(self, sport_name, sport_cls):
+            run_sports.append(sport_name)
+            return None
 
     monkeypatch.setattr(db_main, "load_vips", _load_vips_once)
-    monkeypatch.setattr(db_main, "process_sport", _fake_process_sport)
+    monkeypatch.setattr(db_main, "SportProcessor", _FakeSportProcessor)
     monkeypatch.setattr(
         db_main.argparse.ArgumentParser,
         "parse_args",
@@ -634,7 +620,8 @@ def test_main_loads_vips_once_per_invocation(monkeypatch, tmp_path):
     db_main.main()
 
     assert calls["load_vips"] == 1
-    assert process_vip_args == [["UserA"], ["UserA"]]
+    assert captured_vips == ["UserA"]
+    assert run_sports == ["NFL", "GOLF"]
 
 
 def test_write_snapshot_payload_is_byte_stable(tmp_path):


### PR DESCRIPTION
Deepening opportunity #5: process_sport was a 100-line function with no
injection points, constructing all I/O dependencies (Draftkings, sheet,
sqlite3) inline and making the workflow untestable without hitting real APIs.

SportProcessor owns the full "process one sport → write sheet" pipeline
behind run(sport_name, sport_cls) -> int. Three injected ports — DkPort,
SheetPort (via sheet_factory callable), BonusSenderPort — cover the true
external dependencies. ContestDatabase is injected directly (local-
substitutable). Typed exceptions (NoLiveContestError, StandingsUnavailableError,
StandsParseError) replace the scattered None-return skip pattern.

db_main.py shrinks from ~670 lines to ~140: arg parsing, SportProcessor
construction, sport loop, snapshot output. All workflow logic lives in one
testable place.

https://claude.ai/code/session_01EFqJHhP74AGTCito6Jpi5X