### PR TITLE
refactor(sport_processor): remove skip-path vip logs and expired compat aliases

### DIFF
--- a/src/dk_results/sport_processor.py
+++ b/src/dk_results/sport_processor.py
@@ -23,14 +23,6 @@ from dk_results.vip_lineups import build_vip_entries, fetch_vip_lineups
 
 logger = logging.getLogger(__name__)
 
-_LEGACY_VIP_EVENT_COMPAT_ENV = "DK_VIP_EVENT_COMPAT"
-_LEGACY_VIP_EVENT_REMOVE_AFTER = "2026-04-30"
-_LEGACY_VIP_EVENT_MAP = {
-    "vip_detection": "vip_detection_summary",
-    "vip_fetch": "vip_lineups_fetch",
-    "vip_sheet_write": "vip_lineups_summary",
-}
-
 
 # ── Ports ──────────────────────────────────────────────────────────────────────
 
@@ -155,7 +147,6 @@ class SportProcessor:
         result = self._db.get_live_contest(sport_cls.name, sport_cls.sheet_min_entry_fee, sport_cls.keyword)
         if not result:
             logger.warning("There are no live contests for %s! Moving on.", sport_name)
-            self._log_vip_skip_events(sport_name, None, len(self._vips), "not_applicable")
             raise NoLiveContestError(sport_name)
 
         dk_id, name, draft_group, positions_paid, _start_date = result
@@ -173,7 +164,6 @@ class SportProcessor:
         )
         if not contest_list:
             logger.warning("Contest standings download failed or was empty for dk_id=%s; skipping.", dk_id)
-            self._log_vip_skip_events(sport_name, int(dk_id), len(self._vips), "standings_unavailable")
             raise StandingsUnavailableError(sport_name)
 
         sheet = self._sheet_factory(sport_name)
@@ -188,7 +178,6 @@ class SportProcessor:
             )
         except Exception:
             logger.exception("Failed to parse contest standings: sport=%s contest_id=%s", sport_name, dk_id)
-            self._log_vip_skip_events(sport_name, int(dk_id), len(self._vips), "results_unavailable")
             raise StandsParseError(sport_name)
 
         self._maybe_write_optimal_lineup(sheet=sheet, results=results, sport_cls=sport_cls, sport_name=sport_name)
@@ -469,24 +458,10 @@ class SportProcessor:
     def _format_event_fields(cls, fields: dict[str, Any]) -> str:
         return " ".join(f"{k}={cls._format_log_value(v)}" for k, v in fields.items())
 
-    @staticmethod
-    def _compat_events_enabled() -> bool:
-        value = os.getenv(_LEGACY_VIP_EVENT_COMPAT_ENV, "1").strip().lower()
-        return value not in {"0", "false", "no"}
-
     @classmethod
     def _log_structured_info(cls, event: str, **fields: Any) -> None:
         body = cls._format_event_fields(fields)
         logger.info("%s %s", event, body)
-        legacy_event = _LEGACY_VIP_EVENT_MAP.get(event)
-        if legacy_event and cls._compat_events_enabled():
-            logger.info(
-                "%s %s deprecated=true remove_after=%s canonical=%s",
-                legacy_event,
-                body,
-                _LEGACY_VIP_EVENT_REMOVE_AFTER,
-                event,
-            )
 
     @classmethod
     def _log_vip_detection(
@@ -548,31 +523,3 @@ class SportProcessor:
             reason=reason,
         )
 
-    @classmethod
-    def _log_vip_skip_events(cls, sport_name: str, contest_id: int | None, requested: int, reason: str) -> None:
-        cls._log_vip_detection(
-            sport=sport_name,
-            contest_id=contest_id,
-            requested=requested,
-            found=0,
-            attempted=False,
-            reason=reason,
-        )
-        cls._log_vip_fetch(
-            sport=sport_name,
-            contest_id=contest_id,
-            requested=requested,
-            fetched=0,
-            missing_roster=0,
-            failures=0,
-            attempted=False,
-            reason=reason,
-        )
-        cls._log_vip_sheet_write(
-            sport=sport_name,
-            contest_id=contest_id,
-            lineups=0,
-            written=False,
-            elapsed_ms=0,
-            reason=reason,
-        )

--- a/src/dk_results/sport_processor.py
+++ b/src/dk_results/sport_processor.py
@@ -522,4 +522,3 @@ class SportProcessor:
             elapsed_ms=elapsed_ms,
             reason=reason,
         )
-

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -261,15 +261,14 @@ def test_process_sport_handles_no_live_contest(caplog):
         with pytest.raises(NoLiveContestError):
             processor.run("NFL", NFLSport)
 
-    detection = _event_messages(caplog, "vip_detection")
-    fetch = _event_messages(caplog, "vip_fetch")
-    sheet_write = _event_messages(caplog, "vip_sheet_write")
-    assert len(detection) == 1
-    assert len(fetch) == 1
-    assert len(sheet_write) == 1
+    assert len(_event_messages(caplog, "vip_detection")) == 0
+    assert len(_event_messages(caplog, "vip_fetch")) == 0
+    assert len(_event_messages(caplog, "vip_sheet_write")) == 0
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("no live contests" in m.lower() for m in warning_msgs)
 
 
-def test_process_sport_emits_deterministic_vip_events_for_standings_skip(tmp_path, caplog):
+def test_process_sport_emits_no_vip_events_for_standings_skip(tmp_path, caplog):
     processor = _make_processor(
         _FakeContestDb(),
         vips=["UserA"],
@@ -280,15 +279,9 @@ def test_process_sport_emits_deterministic_vip_events_for_standings_skip(tmp_pat
         with pytest.raises(StandingsUnavailableError):
             processor.run("NFL", NFLSport)
 
-    detection = _event_messages(caplog, "vip_detection")
-    fetch = _event_messages(caplog, "vip_fetch")
-    sheet_write = _event_messages(caplog, "vip_sheet_write")
-    assert len(detection) == 1
-    assert len(fetch) == 1
-    assert len(sheet_write) == 1
-    assert _parse_event_fields(detection[0])["reason"] == "standings_unavailable"
-    assert _parse_event_fields(fetch[0])["attempted"] == "false"
-    assert _parse_event_fields(sheet_write[0])["written"] == "false"
+    assert len(_event_messages(caplog, "vip_detection")) == 0
+    assert len(_event_messages(caplog, "vip_fetch")) == 0
+    assert len(_event_messages(caplog, "vip_sheet_write")) == 0
 
 
 def test_process_sport_emits_fetch_error_reason_to_fetch_and_sheet_events(monkeypatch, tmp_path, caplog):
@@ -335,7 +328,7 @@ def test_vip_fetch_requested_uses_filtered_entry_keys(monkeypatch, tmp_path, cap
     assert _parse_event_fields(fetch[0])["requested"] == "1"
 
 
-def test_process_sport_emits_vip_events_when_results_build_fails(monkeypatch, tmp_path, caplog):
+def test_process_sport_emits_no_vip_events_when_results_build_fails(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(
         SportProcessor,
         "_build_results",
@@ -346,15 +339,9 @@ def test_process_sport_emits_vip_events_when_results_build_fails(monkeypatch, tm
         with pytest.raises(StandsParseError):
             processor.run("NFL", NFLSport)
 
-    detection = _event_messages(caplog, "vip_detection")
-    fetch = _event_messages(caplog, "vip_fetch")
-    sheet_write = _event_messages(caplog, "vip_sheet_write")
-    assert len(detection) == 1
-    assert len(fetch) == 1
-    assert len(sheet_write) == 1
-    assert _parse_event_fields(detection[0])["reason"] == "results_unavailable"
-    assert _parse_event_fields(fetch[0])["reason"] == "results_unavailable"
-    assert _parse_event_fields(sheet_write[0])["reason"] == "results_unavailable"
+    assert len(_event_messages(caplog, "vip_detection")) == 0
+    assert len(_event_messages(caplog, "vip_fetch")) == 0
+    assert len(_event_messages(caplog, "vip_sheet_write")) == 0
 
 
 def test_process_sport_logs_optimizer_skip(tmp_path, caplog):
@@ -394,21 +381,6 @@ def test_process_sport_emits_deterministic_vip_events_on_happy_path(monkeypatch,
     assert sheet_fields["written"] == "true"
     assert sheet_fields["lineups"] == "1"
 
-
-def test_vip_event_compatibility_mode(monkeypatch, tmp_path, caplog):
-    monkeypatch.setenv("DK_VIP_EVENT_COMPAT", "1")
-    monkeypatch.setattr(
-        "dk_results.sport_processor.fetch_vip_lineups",
-        lambda *_a, **_kw: [_FakeVipLineup()],
-    )
-    processor = _make_processor(_FakeContestDb(), vips=["UserA"], salary_dir=str(tmp_path))
-    with caplog.at_level(logging.INFO):
-        processor.run("NFL", NFLSport)
-
-    assert len(_event_messages(caplog, "vip_detection_summary")) == 1
-    assert len(_event_messages(caplog, "vip_lineups_fetch")) == 1
-    assert len(_event_messages(caplog, "vip_lineups_summary")) == 1
-    assert "remove_after=2026-04-30" in caplog.text
 
 
 def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):

--- a/tests/test_db_main.py
+++ b/tests/test_db_main.py
@@ -382,7 +382,6 @@ def test_process_sport_emits_deterministic_vip_events_on_happy_path(monkeypatch,
     assert sheet_fields["lineups"] == "1"
 
 
-
 def test_main_snapshot_out_writes_opt_in_envelope(monkeypatch, tmp_path):
     out = tmp_path / "snapshot.json"
     monkeypatch.setattr(db_main, "load_dotenv", lambda: None)


### PR DESCRIPTION
## Summary
- When a sport has no live contests (or standings/parse failures), only the existing WARNING/EXCEPTION is emitted — removes 6 redundant structured INFO lines
- Deletes expired deprecated compat aliases (`vip_detection_summary`, `vip_lineups_fetch`, `vip_lineups_summary`) scheduled for removal after 2026-04-30
- Net: -94 lines / +13 lines across two files

## Test Plan
- [ ] 448 tests pass (`uv run pytest tests/`)
- [ ] Run locally with no live contests and confirm only the WARNING appears
- [ ] Run with a live contest and confirm 3 structured lines appear (not 6)