### PR TITLE
Add MLB home run bonus announcements

### DIFF
--- a/src/dk_results/classes/bonus_announcements.py
+++ b/src/dk_results/classes/bonus_announcements.py
@@ -46,6 +46,14 @@ BONUS_META: dict[str, dict[str, dict[str, Any]]] = {
             "count_mode": "binary",
         },
     },
+    "MLB": {
+        "HR": {
+            "label": "home run",
+            "action": "hit a home run",
+            "points": 10,
+            "count_mode": "incremental",
+        },
+    },
 }
 
 

--- a/src/dk_results/classes/bonus_rules.py
+++ b/src/dk_results/classes/bonus_rules.py
@@ -7,6 +7,7 @@ import re
 _GOLF_TOKEN_RE = re.compile(r"(?<!\w)(\d+)\s*(EAG|BOFR|BIR3\+)(?!\w)")
 _NBA_DDBL_RE = re.compile(r"\bDDbl\b")
 _NBA_TDBL_RE = re.compile(r"\bTDbl\b")
+_MLB_HR_RE = re.compile(r"(?<!\w)(\d+)\s*HR(?!\w)")
 
 
 def _parse_golf_bonus_counts(stats_description: str) -> dict[str, int]:
@@ -29,10 +30,20 @@ def _parse_nba_bonus_counts(stats_description: str) -> dict[str, int]:
     return counts
 
 
+def _parse_mlb_bonus_counts(stats_description: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    m = _MLB_HR_RE.search(stats_description or "")
+    if m and (n := int(m.group(1))) > 0:
+        counts["HR"] = n
+    return counts
+
+
 def parse_bonus_counts(sport: str, stats_description: str) -> dict[str, int]:
     """Parse bonus counts from a DK statsDescription string for a supported sport."""
     if sport == "GOLF":
         return _parse_golf_bonus_counts(stats_description)
     if sport == "NBA":
         return _parse_nba_bonus_counts(stats_description)
+    if sport == "MLB":
+        return _parse_mlb_bonus_counts(stats_description)
     return {}

--- a/tests/classes/test_bonus_rules.py
+++ b/tests/classes/test_bonus_rules.py
@@ -29,3 +29,27 @@ def test_parse_bonus_counts_nba_absent_tokens():
     stats = "10 REB, 12 AST, 28 PTS"
     counts = parse_bonus_counts("NBA", stats)
     assert counts == {}
+
+
+def test_parse_bonus_counts_mlb_detects_home_run():
+    stats = "3 AB, 2 H, 1 HR, 2 RBI, 1 R"
+    counts = parse_bonus_counts("MLB", stats)
+    assert counts == {"HR": 1}
+
+
+def test_parse_bonus_counts_mlb_detects_multi_hr():
+    stats = "4 AB, 2 HR, 5 RBI, 2 R"
+    counts = parse_bonus_counts("MLB", stats)
+    assert counts == {"HR": 2}
+
+
+def test_parse_bonus_counts_mlb_no_hr():
+    stats = "3 AB, 2 H, 2 RBI, 1 R"
+    counts = parse_bonus_counts("MLB", stats)
+    assert counts == {}
+
+
+def test_parse_bonus_counts_mlb_zero_hr_ignored():
+    stats = "3 AB, 0 HR, 1 H"
+    counts = parse_bonus_counts("MLB", stats)
+    assert counts == {}


### PR DESCRIPTION
Adds HR detection to the bonus announcement pipeline for MLB slates.
Follows the existing incremental pattern used by GOLF bonuses.

https://claude.ai/code/session_01B6L6Xyz31BwSVLuW9A3kyY