### PR TITLE
fix(soccer): restrict SOC to classic, add SOCShowdown sport

### DIFF
--- a/src/dk_results/classes/sport.py
+++ b/src/dk_results/classes/sport.py
@@ -299,5 +299,6 @@ class SOCSport(Sport):
     lineup_range = "J3:W999"
 
     dub_min_entries = 50
+    contest_restraint_game_type_id = 122
 
     positions = ["F", "F", "M", "M", "D", "D", "GK", "UTIL"]

--- a/src/dk_results/classes/sport.py
+++ b/src/dk_results/classes/sport.py
@@ -302,3 +302,14 @@ class SOCSport(Sport):
     contest_restraint_game_type_id = 122
 
     positions = ["F", "F", "M", "M", "D", "D", "GK", "UTIL"]
+
+
+class SOCShowdownSport(Sport):
+    name = "SOCShowdown"
+    sport_name = "SOC"
+    lineup_range = "J3:W999"
+
+    contest_restraint_game_type_id = 123
+
+    positions = ["CPT", "FLEX"]
+    allow_optimizer = False


### PR DESCRIPTION
## Summary
- Restrict `SOCSport` to classic contests only (`contest_restraint_game_type_id = 122`) — fixes showdown double-ups being picked up by `find_new_double_ups`
- Add `SOCShowdownSport` (game_type_id 123, CPT/FLEX, optimizer disabled) for opt-in showdown support

## Test Plan
- [ ] `find_new_double_ups -s SOC` no longer returns showdown contests
- [ ] `dkcontests --sport-class SOC` returns only Classic game type
- [ ] `dkcontests --sport-class SOCShowdown` returns only Showdown game type